### PR TITLE
Add claim schemas

### DIFF
--- a/c2pa/claim-examples/claim_create.json
+++ b/c2pa/claim-examples/claim_create.json
@@ -1,0 +1,98 @@
+{
+    "vendor": "starlinglab",
+    "recorder": "Starling Capture",
+    "assertions": [
+        {
+            "label": "stds.schema-org.CreativeWork",
+            "data": {
+                "@context": "https://schema.org",
+                "@type": "CreativeWork",
+                "author": [
+                    {
+                        "@type": "Person",
+                        "credential": [
+                        ],
+                        "identifier": "https://hypha.coop",
+                        "name": "Benedict Lau"
+                    }
+                ]
+            }
+        },
+        {
+            "label": "c2pa.actions",
+            "data": {
+                "actions": [
+                    {
+                        "action": "c2pa.created",
+                        "when": "2021-12-10T12:08:20.440259822+00:00"
+                    }
+                ]
+            }
+        },
+        {
+            "label": "stds.exif",
+            "data": {
+                "@context": {
+                    "exif": "http://ns.adobe.com/exif/1.0/"
+                },
+                "exif:GPSLatitude": "22/1 16/1 380219916977963/8796093022208",
+                "exif:GPSLatitudeRef": "N",
+                "exif:GPSLongitude": "114/1 10/1 4036351166030807/70368744177664",
+                "exif:GPSLongitudeRef": "E",
+                "exif:GPSTimeStamp": "2021:12:10 11:23:40 +0000"
+            }
+        },
+        {
+            "label": "stds.iptc.photo-metadata",
+            "data": {
+                "@context": {
+                    "Iptc4xmpExt": "http://iptc.org/std/Iptc4xmpExt/2008-02-29/",
+                    "dc" : "http://purl.org/dc/elements/1.1/"
+                },
+                "dc:creator": [
+                    "Benedict Lau"
+                ],
+                "dc:rights": "Copyright (C) 2021 Hypha Worker Co-operative. All Rights Reserved.",
+                "Iptc4xmpExt:LocationCreated": {
+                    "Iptc4xmpExt:CountryCode": "cn",
+                    "Iptc4xmpExt:CountryName": "中国",
+                    "Iptc4xmpExt:ProviceState": "香港 Hong Kong"
+                }
+            }
+        },
+        {
+            "label": "org.starlinglab.integrity",
+            "data": {
+                "starling:identifier": "109213b0e49d5eba0ebd679a9e87d33eebd8dc47255ae5043022f512052f0f9b",
+                "starling:signatures": [
+                    {
+                        "starling:provider": "AndroidOpenSSL",
+                        "starling:algorithm": "numbers-AndroidOpenSSL",
+                        "starling:publicKey": "3059301306072a8648ce3d020106082a8648ce3d0301070342000463760bc21e0f0d2fa4186c67f06e866fa075fc50a28fa9330299ac9f3b31af87ffa06aca9749085a6da162b1b685a4deeba93fecfae94c7706d55e370384cb91",
+                        "starling:signature": "304502200e57c4795f3a674b334332089a50ecf02dad72d5b9297db55bf67e3454f79289022100a927f5cfb7728c9b9650102f076f956918953dc3cbd0ab51f6dc1bbf7a6dceb5",
+                        "starling:authenticatedMessage": "109213b0e49d5eba0ebd679a9e87d33eebd8dc47255ae5043022f512052f0f9b",
+                        "starling:authenticatedMessageDescription": "Internal identifier of the authenticated bundle",
+                        "starling:authenticatedMessagePublic": {
+                            "starling:assetHash": "109213b0e49d5eba0ebd679a9e87d33eebd8dc47255ae5043022f512052f0f9b",
+                            "starling:assetMimeType": "image/jpeg",
+                            "starling:assetCreatedTimestamp": "2021-12-10T12:08:20.440259822+00:00"
+                        }
+                    },
+                    {
+                        "starling:provider": "Zion",
+                        "starling:algorithm": "numbers-AndroidOpenSSL",
+                        "starling:publicKey": "Session:\n3059301306072a8648ce3d020106082a8648ce3d0301070342000405ec1b30b3de4c902d72f36d229a5004fcf1549d84bcc6a69eea8ea1079d350ca51b2f38403126bae55fbc528c58c6c249e6e2137aa6426008275b3c27819f76\n\nReceive:\n02e82c5c55f377c87399cb2d272f5e5859ed0310111807635a0cf58fb3e52f6524\n\nSend:\n02e82c5c55f377c87399cb2d272f5e5859ed0310111807635a0cf58fb3e52f6524",
+                        "starling:signature": "3045022100e2fc3bb9ca1f18aeff3c6d424b69cf6ce243f1aa594b3c609c0395c687f795ae022049b31956302fc5750aa645f0f5d03a1d3c67b49216090cfcf2dc3833e8af2dab",
+                        "starling:authenticatedMessage": "109213b0e49d5eba0ebd679a9e87d33eebd8dc47255ae5043022f512052f0f9b",
+                        "starling:authenticatedMessageDescription": "Internal identifier of the authenticated bundle",
+                        "starling:authenticatedMessagePublic": {
+                            "starling:assetHash": "109213b0e49d5eba0ebd679a9e87d33eebd8dc47255ae5043022f512052f0f9b",
+                            "starling:assetMimeType": "image/jpeg",
+                            "starling:assetCreatedTimestamp": "2021-12-10T12:08:20.440259822+00:00"
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/c2pa/claim-examples/claim_create.json
+++ b/c2pa/claim-examples/claim_create.json
@@ -14,6 +14,12 @@
                         ],
                         "identifier": "https://hypha.coop",
                         "name": "Benedict Lau"
+                    },
+                    {
+                        "@id": "https://twitter.com/HyphaCoop",
+                        "@type": "Organization",
+                        "identifier": "https://hypha.coop",
+                        "name": "Hypha Worker Co-operative"
                     }
                 ]
             }
@@ -80,7 +86,7 @@
                     },
                     {
                         "starling:provider": "Zion",
-                        "starling:algorithm": "numbers-AndroidOpenSSL",
+                        "starling:algorithm": "numbers-Zion",
                         "starling:publicKey": "Session:\n3059301306072a8648ce3d020106082a8648ce3d0301070342000405ec1b30b3de4c902d72f36d229a5004fcf1549d84bcc6a69eea8ea1079d350ca51b2f38403126bae55fbc528c58c6c249e6e2137aa6426008275b3c27819f76\n\nReceive:\n02e82c5c55f377c87399cb2d272f5e5859ed0310111807635a0cf58fb3e52f6524\n\nSend:\n02e82c5c55f377c87399cb2d272f5e5859ed0310111807635a0cf58fb3e52f6524",
                         "starling:signature": "3045022100e2fc3bb9ca1f18aeff3c6d424b69cf6ce243f1aa594b3c609c0395c687f795ae022049b31956302fc5750aa645f0f5d03a1d3c67b49216090cfcf2dc3833e8af2dab",
                         "starling:authenticatedMessage": "109213b0e49d5eba0ebd679a9e87d33eebd8dc47255ae5043022f512052f0f9b",

--- a/c2pa/claim-examples/claim_store.json
+++ b/c2pa/claim-examples/claim_store.json
@@ -14,6 +14,19 @@
                         ],
                         "identifier": "https://starlinglab.org",
                         "name": "Starling Lab"
+                    },
+                    {
+                        "@type": "Organization",
+                        "credential": [
+                        ],
+                        "identifier": "https://scmp.com",
+                        "name": "South China Morning Post"
+                    },
+                    {
+                        "@id": "https://twitter.com/SCMPNews",
+                        "@type": "Organization",
+                        "identifier": "https://scmp.com",
+                        "name": "South China Morning Post"
                     }
                 ]
             }

--- a/c2pa/claim-examples/claim_store.json
+++ b/c2pa/claim-examples/claim_store.json
@@ -1,0 +1,41 @@
+{
+    "vendor": "starlinglab",
+    "recorder": "Starling Integrity",
+    "assertions": [
+        {
+            "label": "stds.schema-org.CreativeWork",
+            "data": {
+                "@context": "https://schema.org",
+                "@type": "CreativeWork",
+                "author": [
+                    {
+                        "@type": "Organization",
+                        "credential": [
+                        ],
+                        "identifier": "https://starlinglab.org",
+                        "name": "Starling Lab"
+                    }
+                ]
+            }
+        },
+        {
+            "label": "c2pa.actions",
+            "data": {
+                "actions": [
+                    {
+                        "action": "c2pa.saved",
+                        "when": "2021-12-10T12:08:20.440259822+00:00"
+                    }
+                ]
+            }
+        },
+        {
+            "label": "org.starlinglab.storage.ipfs",
+            "data": {
+                "starling:provider": "Web3.Storage",
+                "starling:ipfsCid": "bafkreih7bbt4et4yltu3wnhk2jknus77huhgdd723csvadvhgoc7d5lqm4",
+                "starling:assetStoredTimestamp": "2021-12-10T12:08:20.440259822+00:00"
+            }
+        }
+    ]
+}

--- a/c2pa/claim-examples/claim_update.json
+++ b/c2pa/claim-examples/claim_update.json
@@ -29,7 +29,7 @@
             "data": {
                 "actions": [
                     {
-                        "action": "c2pa.edited",
+                        "action": "c2pa.unknown",
                         "when": "2021-12-10T12:08:20.440259822+00:00"
                     }
                 ]

--- a/c2pa/claim-examples/claim_update.json
+++ b/c2pa/claim-examples/claim_update.json
@@ -1,0 +1,33 @@
+{
+    "vendor": "starlinglab",
+    "recorder": "Starling Integrity",
+    "assertions": [
+        {
+            "label": "stds.schema-org.CreativeWork",
+            "data": {
+                "@context": "https://schema.org",
+                "@type": "CreativeWork",
+                "author": [
+                    {
+                        "@type": "Organization",
+                        "credential": [
+                        ],
+                        "identifier": "https://scmp.com",
+                        "name": "South China Morning Post"
+                    }
+                ]
+            }
+        },
+        {
+            "label": "c2pa.actions",
+            "data": {
+                "actions": [
+                    {
+                        "action": "c2pa.edited",
+                        "when": "2021-12-10T12:08:20.440259822+00:00"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/c2pa/claim-examples/claim_update.json
+++ b/c2pa/claim-examples/claim_update.json
@@ -14,6 +14,12 @@
                         ],
                         "identifier": "https://scmp.com",
                         "name": "South China Morning Post"
+                    },
+                    {
+                        "@id": "https://twitter.com/SCMPNews",
+                        "@type": "Organization",
+                        "identifier": "https://scmp.com",
+                        "name": "South China Morning Post"
                     }
                 ]
             }

--- a/c2pa/claim-templates/claim_create.json
+++ b/c2pa/claim-templates/claim_create.json
@@ -1,0 +1,88 @@
+{
+    "vendor": "starlinglab",
+    "recorder": "{{recorder}}",
+    "assertions": [
+        {
+            "label": "stds.schema-org.CreativeWork",
+            "data": {
+                "@context": "https://schema.org",
+                "@type": "CreativeWork",
+                "author": [
+                    {
+                        "@type": "{{author_type}}",
+                        "credential": [
+                        ],
+                        "identifier": "{{author_identifier}}",
+                        "name": "{{author_name}}"
+                    }
+                ]
+            }
+        },
+        {
+            "label": "c2pa.actions",
+            "data": {
+                "actions": [
+                    {
+                        "action": "c2pa.created",
+                        "when": "{{authenticated_asset_created_timestamp}}"
+                    }
+                ]
+            }
+        },
+        {
+            "label": "stds.exif",
+            "data": {
+                "@context": {
+                    "exif": "http://ns.adobe.com/exif/1.0/"
+                },
+                "exif:GPSLatitude": "{{gps_latitude}}",
+                "exif:GPSLatitudeRef": "{{gps_latitude_ref}}",
+                "exif:GPSLongitude": "{{gps_longitude}}",
+                "exif:GPSLongitudeRef": "{{gps_longitude_ref}}",
+                "exif:GPSTimeStamp": "{{gps_timestamp}}"
+            }
+        },
+        {
+            "label": "stds.iptc.photo-metadata",
+            "data": {
+                "@context": {
+                    "Iptc4xmpExt": "http://iptc.org/std/Iptc4xmpExt/2008-02-29/",
+                    "dc" : "http://purl.org/dc/elements/1.1/"
+                },
+                "dc:creator": [
+                    "{{author_name}}"
+                ],
+                "dc:rights": "{{copyright}}",
+                "Iptc4xmpExt:LocationCreated": {
+                    "Iptc4xmpExt:CountryCode": "{{location_country_code}}",
+                    "Iptc4xmpExt:CountryName": "{{location_country_name}}",
+                    "Iptc4xmpExt:ProviceState": "{{location_province_state}}",
+                    "Iptc4xmpExt:City": "{{location_city}}",
+                    "Iptc4xmpExt:Sublocation": "{{location_sublocation}}",
+                    "Iptc4xmpExt:LocationDetails": "{{location_location_details}}"
+                }
+            }
+        },
+        {
+            "label": "org.starlinglab.integrity",
+            "data": {
+                "starling:identifier": "{{starling_identifier}}",
+                "starling:signatures": [
+                    {
+                        "starling:provider": "{{signature_provider}}",
+                        "starling:algorithm": "{{signature_algorithm}}",
+                        "starling:publicKey": "{{signature_public_key}}",
+                        "starling:signature": "{{signature_signature}}",
+                        "starling:authenticatedMessage": "{{signature_authenticated_message}}",
+                        "starling:authenticatedMessageDescription": "{{signature_authenticated_message_description}}",
+                        "starling:authenticatedMessagePublic": {
+                            "starling:assetHash": "{{authenticated_asset_hash}}",
+                            "starling:assetMimeType": "{{authenticated_asset_mime_type}}",
+                            "starling:assetCreatedTimestamp": "{{authenticated_asset_created_timestamp}}"
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/c2pa/claim-templates/claim_create.json
+++ b/c2pa/claim-templates/claim_create.json
@@ -14,6 +14,12 @@
                         ],
                         "identifier": "{{author_identifier}}",
                         "name": "{{author_name}}"
+                    },
+                    {
+                        "@id": "https://twitter.com/{{twitter_handle}}",
+                        "@type": "{{twitter_type}}",
+                        "identifier": "{{twitter_identifier}}",
+                        "name": "{{twitter_name}}"
                     }
                 ]
             }

--- a/c2pa/claim-templates/claim_store.json
+++ b/c2pa/claim-templates/claim_store.json
@@ -1,0 +1,41 @@
+{
+    "vendor": "starlinglab",
+    "recorder": "{{recorder}}",
+    "assertions": [
+        {
+            "label": "stds.schema-org.CreativeWork",
+            "data": {
+                "@context": "https://schema.org",
+                "@type": "CreativeWork",
+                "author": [
+                    {
+                        "@type": "{{author_type}}",
+                        "credential": [
+                        ],
+                        "identifier": "{{author_identifier}}",
+                        "name": "{{author_name}}"
+                    }
+                ]
+            }
+        },
+        {
+            "label": "c2pa.actions",
+            "data": {
+                "actions": [
+                    {
+                        "action": "c2pa.saved",
+                        "when": "{{asset_stored_timestamp}}"
+                    }
+                ]
+            }
+        },
+        {
+            "label": "org.starlinglab.storage.ipfs",
+            "data": {
+                "starling:provider": "{{ipfs_provider}}",
+                "starling:ipfsCID": "{{ipfs_cid}}",
+                "starling:assetStoredTimestamp": "{{asset_stored_timestamp}}"
+            }
+        }
+    ]
+}

--- a/c2pa/claim-templates/claim_store.json
+++ b/c2pa/claim-templates/claim_store.json
@@ -14,6 +14,12 @@
                         ],
                         "identifier": "{{author_identifier}}",
                         "name": "{{author_name}}"
+                    },
+                    {
+                        "@id": "https://twitter.com/{{twitter_handle}}",
+                        "@type": "{{twitter_type}}",
+                        "identifier": "{{twitter_identifier}}",
+                        "name": "{{twitter_name}}"
                     }
                 ]
             }

--- a/c2pa/claim-templates/claim_update.json
+++ b/c2pa/claim-templates/claim_update.json
@@ -1,0 +1,33 @@
+{
+    "vendor": "starlinglab",
+    "recorder": "{{recorder}}",
+    "assertions": [
+        {
+            "label": "stds.schema-org.CreativeWork",
+            "data": {
+                "@context": "https://schema.org",
+                "@type": "CreativeWork",
+                "author": [
+                    {
+                        "@type": "{{author_type}}",
+                        "credential": [
+                        ],
+                        "identifier": "{{author_identifier}}",
+                        "name": "{{author_name}}"
+                    }
+                ]
+            }
+        },
+        {
+            "label": "c2pa.actions",
+            "data": {
+                "actions": [
+                    {
+                        "action": "c2pa.edited",
+                        "when": "{{asset_edited_timestamp}}"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/c2pa/claim-templates/claim_update.json
+++ b/c2pa/claim-templates/claim_update.json
@@ -14,6 +14,12 @@
                         ],
                         "identifier": "{{author_identifier}}",
                         "name": "{{author_name}}"
+                    },
+                    {
+                        "@id": "https://twitter.com/{{twitter_handle}}",
+                        "@type": "{{twitter_type}}",
+                        "identifier": "{{twitter_identifier}}",
+                        "name": "{{twitter_name}}"
                     }
                 ]
             }

--- a/c2pa/claim-templates/claim_update.json
+++ b/c2pa/claim-templates/claim_update.json
@@ -29,8 +29,8 @@
             "data": {
                 "actions": [
                     {
-                        "action": "c2pa.edited",
-                        "when": "{{asset_edited_timestamp}}"
+                        "action": "c2pa.unknown",
+                        "when": "{{asset_unknown_timestamp}}"
                     }
                 ]
             }


### PR DESCRIPTION
Please review the following schemas that we plan to use for SCMP assets.

There are three schemas corresponding to three claims:
1. create: when asset and metadata is captured with a photo app (e.g. Starling Capture mobile app)
2. update: when asset is edited by a tool that does not track C2PA actions (e.g. metadata update)
3. store: when assets is stored (in this case to IPFS via Web3.Storage)

Each one has an example.