### PR TITLE
Document schemas used in Integrity Backend

### DIFF
--- a/integrity-backend/README.md
+++ b/integrity-backend/README.md
@@ -1,6 +1,25 @@
 # Schemas
 
+## Table of contents
+
+- [Validated signatures](#validated-signatures)
+- [Meta content](#meta-content)
+    - [input-archiveweb-examples](#input-archiveweb-examples)
+    - [input-browsertrix-examples](#input-browsertrix-examples)
+    - [input-chatbot-examples](#input-chatbot-examples)
+    - [input-dropbox-examples](#input-dropbox-examples)
+    - [input-proofmode-signal-examples](#input-proofmode-signal-examples)
+    - [input-starling-capture-examples](#input-starling-capture-examples)
+- [Meta recorder](#meta-recorder)
+    - [input-archiveweb-examples](#input-archiveweb-examples)
+    - [input-browsertrix-examples](#input-browsertrix-examples)
+    - [input-chatbot-examples](#input-chatbot-examples)
+    - [input-dropbox-examples](#input-dropbox-examples)
+    - [input-proofmode-signal-examples](#input-proofmode-signal-examples)
+    - [input-starling-capture-examples](#input-starling-capture-examples)
+
 ## Validated signatures
+
 Name | Type | Description
 ---- | ---- | -----------
 algorithm | string | 
@@ -11,6 +30,7 @@ publicKey | string |
 signature | string | 
 
 ## Meta content
+
 Name | Type | Description
 ---- | ---- | -----------
 contentMetadata | object | 
@@ -462,6 +482,7 @@ contentMetadata | object |
 timestamp | string | 
 
 ## Meta recorder
+
 Name | Type | Description
 ---- | ---- | -----------
 recorderMetadata | array | 

--- a/integrity-backend/README.md
+++ b/integrity-backend/README.md
@@ -1,0 +1,681 @@
+# Schemas
+
+## Validated signatures
+Name | Type | Description
+---- | ---- | -----------
+algorithm | string | 
+authenticatedMessage | string | 
+authenticatedMessageDescription | string | 
+provider | string | 
+publicKey | string | 
+signature | string | 
+
+## Meta content
+Name | Type | Description
+---- | ---- | -----------
+contentMetadata | object | 
+*contentMetadata.* author | object | 
+*contentMetadata.author.* identifier | string | 
+*contentMetadata.author.* name | string | 
+*contentMetadata.author.* @type | string | *Optional* 
+*contentMetadata.author.* type | string | *Optional* 
+*contentMetadata.* dateCreated | string | 
+*contentMetadata.* description | string | 
+*contentMetadata.* extras | object | 
+*contentMetadata.extras.* authsignDomain | string | *Optional* 
+*contentMetadata.extras.* authsignSoftware | string | *Optional* 
+*contentMetadata.extras.* botType | string | *Optional* 
+*contentMetadata.extras.* caption | string | *Optional* 
+*contentMetadata.extras.* channels | array\<string\> | *Optional* 
+*contentMetadata.extras.* dateCrawled | string | *Optional* 
+*contentMetadata.extras.* dateRage | object | *Optional* 
+*contentMetadata.extras.dateRage.* from | string | 
+*contentMetadata.extras.dateRage.* to | string | 
+*contentMetadata.extras.* localsignPublicKey | string | *Optional* 
+*contentMetadata.extras.* localsignSignature | string | *Optional* 
+*contentMetadata.extras.* localsignSoftware | string | *Optional* 
+*contentMetadata.extras.* pages | object | *Optional* 
+*contentMetadata.extras.pages.* 5ZwqT9xGkYVdYku3EVQLrD | string | *Optional* 
+*contentMetadata.extras.pages.* vngimrkldkpt682awhwrb | string | *Optional* 
+*contentMetadata.extras.* software | string | *Optional* 
+*contentMetadata.extras.* waczTitle | string | *Optional* 
+*contentMetadata.extras.* waczVersion | string | *Optional* 
+*contentMetadata.* mime | string | 
+*contentMetadata.* name | string | 
+*contentMetadata.* private | object | 
+*contentMetadata.private.* additionalData | object | *Optional* 
+*contentMetadata.private.additionalData.* all_codes | array\<string\> | 
+*contentMetadata.private.additionalData.* attached_author | array\<string\> | 
+*contentMetadata.private.additionalData.* attached_service | array\<string\> | 
+*contentMetadata.private.additionalData.* attached_text | array\<string\> | 
+*contentMetadata.private.additionalData.* attached_ts | array\<integer\> | 
+*contentMetadata.private.additionalData.* client_msg_id | string | 
+*contentMetadata.private.additionalData.* country_codes | array\<string\> | 
+*contentMetadata.private.additionalData.* thread_ts | string | 
+*contentMetadata.private.additionalData.* ts | string | 
+*contentMetadata.private.additionalData.* url_list | array\<string\> | 
+*contentMetadata.private.* crawlConfigs | object | *Optional* 
+*contentMetadata.private.crawlConfigs.* aid | string | 
+*contentMetadata.private.crawlConfigs.* colls | array\<string\> | 
+*contentMetadata.private.crawlConfigs.* config | object | 
+*contentMetadata.private.crawlConfigs.config.* behaviorTimeout | null | 
+*contentMetadata.private.crawlConfigs.config.* behaviors | string | 
+*contentMetadata.private.crawlConfigs.config.* combineWARC | null | 
+*contentMetadata.private.crawlConfigs.config.* depth | integer | 
+*contentMetadata.private.crawlConfigs.config.* exclude | null | 
+*contentMetadata.private.crawlConfigs.config.* extraHops | integer | 
+*contentMetadata.private.crawlConfigs.config.* generateWACZ | null | 
+*contentMetadata.private.crawlConfigs.config.* headless | null | 
+*contentMetadata.private.crawlConfigs.config.* include | null | 
+*contentMetadata.private.crawlConfigs.config.* limit | integer | 
+*contentMetadata.private.crawlConfigs.config.* logging | null | 
+*contentMetadata.private.crawlConfigs.config.* scopeType | string | 
+*contentMetadata.private.crawlConfigs.config.* seeds | array\<string\> | 
+*contentMetadata.private.crawlConfigs.config.* workers | null | 
+*contentMetadata.private.crawlConfigs.* crawlCount | integer | 
+*contentMetadata.private.crawlConfigs.* crawlTimeout | integer | 
+*contentMetadata.private.crawlConfigs.* created | string | 
+*contentMetadata.private.crawlConfigs.* currCrawlId | null | 
+*contentMetadata.private.crawlConfigs.* id | string | 
+*contentMetadata.private.crawlConfigs.* inactive | boolean | 
+*contentMetadata.private.crawlConfigs.* lastCrawlId | string | 
+*contentMetadata.private.crawlConfigs.* lastCrawlState | string | 
+*contentMetadata.private.crawlConfigs.* lastCrawlTime | string | 
+*contentMetadata.private.crawlConfigs.* name | string | 
+*contentMetadata.private.crawlConfigs.* newId | null | 
+*contentMetadata.private.crawlConfigs.* oldId | null | 
+*contentMetadata.private.crawlConfigs.* scale | integer | 
+*contentMetadata.private.crawlConfigs.* schedule | string | 
+*contentMetadata.private.crawlConfigs.* userName | string | 
+*contentMetadata.private.crawlConfigs.* userid | string | 
+*contentMetadata.private.* crawlData | object | *Optional* 
+*contentMetadata.private.crawlData.* aid | string | 
+*contentMetadata.private.crawlData.* cid | string | 
+*contentMetadata.private.crawlData.* colls | array\<string\> | 
+*contentMetadata.private.crawlData.* completions | integer | 
+*contentMetadata.private.crawlData.* configName | string | 
+*contentMetadata.private.crawlData.* files | array\<string\> | 
+*contentMetadata.private.crawlData.* finished | string | 
+*contentMetadata.private.crawlData.* id | string | 
+*contentMetadata.private.crawlData.* manual | boolean | 
+*contentMetadata.private.crawlData.* resources | array | 
+*contentMetadata.private.crawlData.* resources[] | object | 
+*contentMetadata.private.crawlData.resources[].* hash | string | 
+*contentMetadata.private.crawlData.resources[].* name | string | 
+*contentMetadata.private.crawlData.resources[].* path | string | 
+*contentMetadata.private.crawlData.resources[].* size | integer | 
+*contentMetadata.private.crawlData.* scale | integer | 
+*contentMetadata.private.crawlData.* started | string | 
+*contentMetadata.private.crawlData.* state | string | 
+*contentMetadata.private.crawlData.* stats | object | 
+*contentMetadata.private.crawlData.stats.* done | string | 
+*contentMetadata.private.crawlData.stats.* found | string | 
+*contentMetadata.private.crawlData.* userName | string | 
+*contentMetadata.private.crawlData.* userid | string | 
+*contentMetadata.private.crawlData.* watchIPs | array\<string\> | 
+*contentMetadata.private.* meta | string | *Optional* 
+*contentMetadata.private.* proofmode | object | *Optional* 
+*contentMetadata.private.proofmode.* 20220608_162522.jpg | object | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.* dateCreate | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.* pgpPublicKey | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.* pgpSignature | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.* proofmodeJSON | object | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* CellInfo | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* DataType | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* DeviceID | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* File Hash SHA256 | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* File Modified | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* File Path | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Hardware | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* IPv4 | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* IPv6 | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Language | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Locale | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Location.Accuracy | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Location.Altitude | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Location.Bearing | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Location.Latitude | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Location.Longitude | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Location.Provider | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Location.Speed | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Location.Time | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Manufacturer | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Network | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* NetworkType | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Notes | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Proof Generated | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* SafetyCheck | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* SafetyCheckBasicIntegrity | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* SafetyCheckCtsMatch | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* SafetyCheckTimestamp | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* ScreenSize | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Wifi MAC | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.* sha256hash | string | 
+*contentMetadata.private.proofmode.* dateCreate | string | 
+*contentMetadata.private.* providerToken | object | *Optional* 
+*contentMetadata.private.providerToken.* author | object | 
+*contentMetadata.private.providerToken.author.* identifier | string | 
+*contentMetadata.private.providerToken.author.* name | string | 
+*contentMetadata.private.providerToken.author.* type | string | 
+*contentMetadata.private.providerToken.* collection_id | string | 
+*contentMetadata.private.providerToken.* organization_id | string | 
+*contentMetadata.private.* signal | object | *Optional* 
+*contentMetadata.private.signal.* body | string | *Optional* 
+*contentMetadata.private.signal.* phoneNumber | string | *Optional* 
+*contentMetadata.private.signal.* source | string | *Optional* 
+*contentMetadata.private.signal.* sourceName | string | *Optional* 
+*contentMetadata.private.signal.* sourceUUID | string | *Optional* 
+*contentMetadata.private.signal.* target | string | *Optional* 
+*contentMetadata.private.signal.* timestamp | string | *Optional* 
+*contentMetadata.private.signal.* timestampServer | string | *Optional* 
+*contentMetadata.private.* signature | array | *Optional* 
+*contentMetadata.private.* signature[] | object | 
+*contentMetadata.private.signature[].* proofHash | string | 
+*contentMetadata.private.signature[].* provider | string | 
+*contentMetadata.private.signature[].* publicKey | string | 
+*contentMetadata.private.signature[].* signature | string | 
+*contentMetadata.private.* slack | object | *Optional* 
+*contentMetadata.private.slack.* botAccount | string | 
+*contentMetadata.private.slack.* workspace | string | 
+*contentMetadata.private.* targetProvider | string | *Optional* 
+*contentMetadata.private.* telegram | object | *Optional* 
+*contentMetadata.private.telegram.* botAccount | string | 
+*contentMetadata.private.* uploadDirectory | string | *Optional* 
+*contentMetadata.private.* uploadFilename | string | *Optional* 
+*contentMetadata.private.* uploaderName | string | *Optional* 
+*contentMetadata.* location | object | *Optional* 
+*contentMetadata.location.* GPSLatitude | string | 
+*contentMetadata.location.* GPSLatitudeRef | string | 
+*contentMetadata.location.* GPSLongitude | string | 
+*contentMetadata.location.* GPSLongitudeRef | string | 
+*contentMetadata.location.* GPSTimeStamp | string | 
+*contentMetadata.location.* city | string | 
+*contentMetadata.location.* countryCode | string | 
+*contentMetadata.location.* countryName | string | 
+*contentMetadata.location.* provinceState | string | 
+*contentMetadata.location.* streetAddress | string | 
+*contentMetadata.* timestamp | string | *Optional* 
+*contentMetadata.* validatedSignature | array | *Optional* 
+*contentMetadata.* validatedSignature[] | object | 
+*contentMetadata.validatedSignature[].* algorithm | string | 
+*contentMetadata.validatedSignature[].* authenticatedMessage | string | 
+*contentMetadata.validatedSignature[].* authenticatedMessageDescription | string | 
+*contentMetadata.validatedSignature[].* provider | string | 
+*contentMetadata.validatedSignature[].* publicKey | string | 
+*contentMetadata.validatedSignature[].* signature | string | 
+*contentMetadata.* validatedSignatures | array | *Optional* 
+*contentMetadata.* validatedSignatures[] | object | 
+*contentMetadata.validatedSignatures[].* algorithm | string | 
+*contentMetadata.validatedSignatures[].* provider | string | 
+*contentMetadata.validatedSignatures[].* authenticatedMessage | string | *Optional* 
+*contentMetadata.validatedSignatures[].* authenticatedMessageDescription | string | *Optional* 
+*contentMetadata.validatedSignatures[].* custom | object | *Optional* 
+*contentMetadata.validatedSignatures[].custom.* 8045cb0d6783638e5828f3cca0ec3aab6ab5b9f8a971faf620a58f6cee1c7ca8.proof.csv | object | *Optional* 
+*contentMetadata.validatedSignatures[].custom.8045cb0d6783638e5828f3cca0ec3aab6ab5b9f8a971faf620a58f6cee1c7ca8.proof.csv.* authenticatedMessage | string | 
+*contentMetadata.validatedSignatures[].custom.8045cb0d6783638e5828f3cca0ec3aab6ab5b9f8a971faf620a58f6cee1c7ca8.proof.csv.* authenticatedMessageDescription | string | 
+*contentMetadata.validatedSignatures[].custom.8045cb0d6783638e5828f3cca0ec3aab6ab5b9f8a971faf620a58f6cee1c7ca8.proof.csv.* signature | string | 
+*contentMetadata.validatedSignatures[].custom.* IMG_123.jpg | object | *Optional* 
+*contentMetadata.validatedSignatures[].custom.IMG_123.jpg.* authenticatedMessage | string | 
+*contentMetadata.validatedSignatures[].custom.IMG_123.jpg.* authenticatedMessageDescription | string | 
+*contentMetadata.validatedSignatures[].custom.IMG_123.jpg.* signature | string | 
+*contentMetadata.validatedSignatures[].custom.* created | string | *Optional* 
+*contentMetadata.validatedSignatures[].custom.* domain | string | *Optional* 
+*contentMetadata.validatedSignatures[].custom.* domainCert | string | *Optional* 
+*contentMetadata.validatedSignatures[].custom.* hash | string | *Optional* 
+*contentMetadata.validatedSignatures[].custom.* signature | string | *Optional* 
+*contentMetadata.validatedSignatures[].custom.* software | string | *Optional* 
+*contentMetadata.validatedSignatures[].custom.* timeSignature | string | *Optional* 
+*contentMetadata.validatedSignatures[].custom.* timestampCert | string | *Optional* 
+*contentMetadata.validatedSignatures[].custom.* version | string | *Optional* 
+*contentMetadata.validatedSignatures[].* publicKey | string | *Optional* 
+*contentMetadata.validatedSignatures[].* signature | string | *Optional* 
+sourceId | object | *Optional* 
+*sourceId.* key | string | 
+*sourceId.* value | string | 
+timestamp | string | *Optional* 
+
+### input-archiveweb-examples
+Name | Type | Description
+---- | ---- | -----------
+contentMetadata | object | 
+*contentMetadata.* author | object | 
+*contentMetadata.author.* @type | string | 
+*contentMetadata.author.* identifier | string | 
+*contentMetadata.author.* name | string | 
+*contentMetadata.* dateCreated | string | 
+*contentMetadata.* description | string | 
+*contentMetadata.* extras | object | 
+*contentMetadata.extras.* dateCrawled | string | 
+*contentMetadata.extras.* localsignPublicKey | string | 
+*contentMetadata.extras.* localsignSignature | string | 
+*contentMetadata.extras.* localsignSoftware | string | 
+*contentMetadata.extras.* pages | object | 
+*contentMetadata.extras.pages.* vngimrkldkpt682awhwrb | string | 
+*contentMetadata.extras.* software | string | 
+*contentMetadata.extras.* waczTitle | string | 
+*contentMetadata.extras.* waczVersion | string | 
+*contentMetadata.* mime | string | 
+*contentMetadata.* name | string | 
+*contentMetadata.* private | object | 
+*contentMetadata.private.* uploadDirectory | string | 
+*contentMetadata.private.* uploadFilename | string | 
+*contentMetadata.private.* uploaderName | string | 
+*contentMetadata.* timestamp | string | 
+*contentMetadata.* validatedSignatures | array | 
+*contentMetadata.* validatedSignatures[] | object | 
+*contentMetadata.validatedSignatures[].* algorithm | string | 
+*contentMetadata.validatedSignatures[].* authenticatedMessage | string | 
+*contentMetadata.validatedSignatures[].* authenticatedMessageDescription | string | 
+*contentMetadata.validatedSignatures[].* provider | string | 
+*contentMetadata.validatedSignatures[].* publicKey | string | 
+*contentMetadata.validatedSignatures[].* signature | string | 
+
+### input-browsertrix-examples
+Name | Type | Description
+---- | ---- | -----------
+contentMetadata | object | 
+*contentMetadata.* author | object | 
+*contentMetadata.author.* @type | string | 
+*contentMetadata.author.* identifier | string | 
+*contentMetadata.author.* name | string | 
+*contentMetadata.* dateCreated | string | 
+*contentMetadata.* description | string | 
+*contentMetadata.* extras | object | 
+*contentMetadata.extras.* authsignDomain | string | 
+*contentMetadata.extras.* authsignSoftware | string | 
+*contentMetadata.extras.* pages | object | 
+*contentMetadata.extras.pages.* 5ZwqT9xGkYVdYku3EVQLrD | string | 
+*contentMetadata.extras.* waczVersion | string | 
+*contentMetadata.* mime | string | 
+*contentMetadata.* name | string | 
+*contentMetadata.* private | object | 
+*contentMetadata.private.* additionalData | object | 
+*contentMetadata.private.additionalData.* all_codes | array\<string\> | 
+*contentMetadata.private.additionalData.* attached_author | array\<string\> | 
+*contentMetadata.private.additionalData.* attached_service | array\<string\> | 
+*contentMetadata.private.additionalData.* attached_text | array\<string\> | 
+*contentMetadata.private.additionalData.* attached_ts | array\<integer\> | 
+*contentMetadata.private.additionalData.* client_msg_id | string | 
+*contentMetadata.private.additionalData.* country_codes | array\<string\> | 
+*contentMetadata.private.additionalData.* thread_ts | string | 
+*contentMetadata.private.additionalData.* ts | string | 
+*contentMetadata.private.additionalData.* url_list | array\<string\> | 
+*contentMetadata.private.* crawlConfigs | object | 
+*contentMetadata.private.crawlConfigs.* aid | string | 
+*contentMetadata.private.crawlConfigs.* colls | array\<string\> | 
+*contentMetadata.private.crawlConfigs.* config | object | 
+*contentMetadata.private.crawlConfigs.config.* behaviorTimeout | null | 
+*contentMetadata.private.crawlConfigs.config.* behaviors | string | 
+*contentMetadata.private.crawlConfigs.config.* combineWARC | null | 
+*contentMetadata.private.crawlConfigs.config.* depth | integer | 
+*contentMetadata.private.crawlConfigs.config.* exclude | null | 
+*contentMetadata.private.crawlConfigs.config.* extraHops | integer | 
+*contentMetadata.private.crawlConfigs.config.* generateWACZ | null | 
+*contentMetadata.private.crawlConfigs.config.* headless | null | 
+*contentMetadata.private.crawlConfigs.config.* include | null | 
+*contentMetadata.private.crawlConfigs.config.* limit | integer | 
+*contentMetadata.private.crawlConfigs.config.* logging | null | 
+*contentMetadata.private.crawlConfigs.config.* scopeType | string | 
+*contentMetadata.private.crawlConfigs.config.* seeds | array\<string\> | 
+*contentMetadata.private.crawlConfigs.config.* workers | null | 
+*contentMetadata.private.crawlConfigs.* crawlCount | integer | 
+*contentMetadata.private.crawlConfigs.* crawlTimeout | integer | 
+*contentMetadata.private.crawlConfigs.* created | string | 
+*contentMetadata.private.crawlConfigs.* currCrawlId | null | 
+*contentMetadata.private.crawlConfigs.* id | string | 
+*contentMetadata.private.crawlConfigs.* inactive | boolean | 
+*contentMetadata.private.crawlConfigs.* lastCrawlId | string | 
+*contentMetadata.private.crawlConfigs.* lastCrawlState | string | 
+*contentMetadata.private.crawlConfigs.* lastCrawlTime | string | 
+*contentMetadata.private.crawlConfigs.* name | string | 
+*contentMetadata.private.crawlConfigs.* newId | null | 
+*contentMetadata.private.crawlConfigs.* oldId | null | 
+*contentMetadata.private.crawlConfigs.* scale | integer | 
+*contentMetadata.private.crawlConfigs.* schedule | string | 
+*contentMetadata.private.crawlConfigs.* userName | string | 
+*contentMetadata.private.crawlConfigs.* userid | string | 
+*contentMetadata.private.* crawlData | object | 
+*contentMetadata.private.crawlData.* aid | string | 
+*contentMetadata.private.crawlData.* cid | string | 
+*contentMetadata.private.crawlData.* colls | array\<string\> | 
+*contentMetadata.private.crawlData.* completions | integer | 
+*contentMetadata.private.crawlData.* configName | string | 
+*contentMetadata.private.crawlData.* files | array\<string\> | 
+*contentMetadata.private.crawlData.* finished | string | 
+*contentMetadata.private.crawlData.* id | string | 
+*contentMetadata.private.crawlData.* manual | boolean | 
+*contentMetadata.private.crawlData.* resources | array | 
+*contentMetadata.private.crawlData.* resources[] | object | 
+*contentMetadata.private.crawlData.resources[].* hash | string | 
+*contentMetadata.private.crawlData.resources[].* name | string | 
+*contentMetadata.private.crawlData.resources[].* path | string | 
+*contentMetadata.private.crawlData.resources[].* size | integer | 
+*contentMetadata.private.crawlData.* scale | integer | 
+*contentMetadata.private.crawlData.* started | string | 
+*contentMetadata.private.crawlData.* state | string | 
+*contentMetadata.private.crawlData.* stats | object | 
+*contentMetadata.private.crawlData.stats.* done | string | 
+*contentMetadata.private.crawlData.stats.* found | string | 
+*contentMetadata.private.crawlData.* userName | string | 
+*contentMetadata.private.crawlData.* userid | string | 
+*contentMetadata.private.crawlData.* watchIPs | array\<string\> | 
+*contentMetadata.* validatedSignatures | array | 
+*contentMetadata.* validatedSignatures[] | object | 
+*contentMetadata.validatedSignatures[].* algorithm | string | 
+*contentMetadata.validatedSignatures[].* custom | object | 
+*contentMetadata.validatedSignatures[].custom.* created | string | 
+*contentMetadata.validatedSignatures[].custom.* domain | string | 
+*contentMetadata.validatedSignatures[].custom.* domainCert | string | 
+*contentMetadata.validatedSignatures[].custom.* hash | string | 
+*contentMetadata.validatedSignatures[].custom.* signature | string | 
+*contentMetadata.validatedSignatures[].custom.* software | string | 
+*contentMetadata.validatedSignatures[].custom.* timeSignature | string | 
+*contentMetadata.validatedSignatures[].custom.* timestampCert | string | 
+*contentMetadata.validatedSignatures[].custom.* version | string | 
+*contentMetadata.validatedSignatures[].* provider | string | 
+sourceId | object | 
+*sourceId.* key | string | 
+*sourceId.* value | string | 
+timestamp | string | 
+
+### input-chatbot-examples
+Name | Type | Description
+---- | ---- | -----------
+contentMetadata | object | 
+*contentMetadata.* author | object | 
+*contentMetadata.author.* @type | string | 
+*contentMetadata.author.* identifier | string | 
+*contentMetadata.author.* name | string | 
+*contentMetadata.* dateCreated | string | 
+*contentMetadata.* description | string | 
+*contentMetadata.* extras | object | 
+*contentMetadata.extras.* channels | array\<string\> | 
+*contentMetadata.extras.* dateRage | object | 
+*contentMetadata.extras.dateRage.* from | string | 
+*contentMetadata.extras.dateRage.* to | string | 
+*contentMetadata.* mime | string | 
+*contentMetadata.* name | string | 
+*contentMetadata.* private | object | 
+*contentMetadata.private.* signal | object | 
+*contentMetadata.private.signal.* phoneNumber | string | 
+*contentMetadata.private.* slack | object | 
+*contentMetadata.private.slack.* botAccount | string | 
+*contentMetadata.private.slack.* workspace | string | 
+*contentMetadata.private.* telegram | object | 
+*contentMetadata.private.telegram.* botAccount | string | 
+timestamp | string | 
+
+### input-dropbox-examples
+Name | Type | Description
+---- | ---- | -----------
+contentMetadata | object | 
+*contentMetadata.* author | object | 
+*contentMetadata.author.* @type | string | 
+*contentMetadata.author.* identifier | string | 
+*contentMetadata.author.* name | string | 
+*contentMetadata.* dateCreated | string | 
+*contentMetadata.* description | string | 
+*contentMetadata.* extras | object | 
+*contentMetadata.* mime | string | 
+*contentMetadata.* name | string | 
+*contentMetadata.* private | object | 
+*contentMetadata.private.* uploadDirectory | string | 
+*contentMetadata.private.* uploadFilename | string | 
+*contentMetadata.private.* uploaderName | string | 
+sourceId | object | 
+*sourceId.* key | string | 
+*sourceId.* value | string | 
+timestamp | string | 
+
+### input-proofmode-signal-examples
+Name | Type | Description
+---- | ---- | -----------
+contentMetadata | object | 
+*contentMetadata.* author | object | 
+*contentMetadata.author.* @type | string | 
+*contentMetadata.author.* identifier | string | 
+*contentMetadata.author.* name | string | 
+*contentMetadata.* dateCreated | string | 
+*contentMetadata.* description | string | 
+*contentMetadata.* extras | object | 
+*contentMetadata.extras.* botType | string | 
+*contentMetadata.* mime | string | 
+*contentMetadata.* name | string | 
+*contentMetadata.* private | object | 
+*contentMetadata.private.* proofmode | object | 
+*contentMetadata.private.proofmode.* 20220608_162522.jpg | object | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.* dateCreate | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.* pgpPublicKey | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.* pgpSignature | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.* proofmodeJSON | object | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* CellInfo | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* DataType | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* DeviceID | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* File Hash SHA256 | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* File Modified | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* File Path | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Hardware | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* IPv4 | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* IPv6 | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Language | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Locale | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Location.Accuracy | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Location.Altitude | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Location.Bearing | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Location.Latitude | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Location.Longitude | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Location.Provider | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Location.Speed | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Location.Time | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Manufacturer | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Network | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* NetworkType | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Notes | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Proof Generated | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* SafetyCheck | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* SafetyCheckBasicIntegrity | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* SafetyCheckCtsMatch | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* SafetyCheckTimestamp | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* ScreenSize | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Wifi MAC | string | 
+*contentMetadata.private.proofmode.20220608_162522.jpg.* sha256hash | string | 
+*contentMetadata.private.proofmode.* dateCreate | string | 
+*contentMetadata.private.* signal | object | 
+*contentMetadata.private.signal.* body | string | 
+*contentMetadata.private.signal.* source | string | 
+*contentMetadata.private.signal.* sourceName | string | 
+*contentMetadata.private.signal.* sourceUUID | string | 
+*contentMetadata.private.signal.* target | string | 
+*contentMetadata.private.signal.* timestamp | string | 
+*contentMetadata.private.signal.* timestampServer | string | 
+*contentMetadata.* validatedSignatures | array | 
+*contentMetadata.* validatedSignatures[] | object | 
+*contentMetadata.validatedSignatures[].* algorithm | string | 
+*contentMetadata.validatedSignatures[].* custom | object | 
+*contentMetadata.validatedSignatures[].custom.* 8045cb0d6783638e5828f3cca0ec3aab6ab5b9f8a971faf620a58f6cee1c7ca8.proof.csv | object | 
+*contentMetadata.validatedSignatures[].custom.8045cb0d6783638e5828f3cca0ec3aab6ab5b9f8a971faf620a58f6cee1c7ca8.proof.csv.* authenticatedMessage | string | 
+*contentMetadata.validatedSignatures[].custom.8045cb0d6783638e5828f3cca0ec3aab6ab5b9f8a971faf620a58f6cee1c7ca8.proof.csv.* authenticatedMessageDescription | string | 
+*contentMetadata.validatedSignatures[].custom.8045cb0d6783638e5828f3cca0ec3aab6ab5b9f8a971faf620a58f6cee1c7ca8.proof.csv.* signature | string | 
+*contentMetadata.validatedSignatures[].custom.* IMG_123.jpg | object | 
+*contentMetadata.validatedSignatures[].custom.IMG_123.jpg.* authenticatedMessage | string | 
+*contentMetadata.validatedSignatures[].custom.IMG_123.jpg.* authenticatedMessageDescription | string | 
+*contentMetadata.validatedSignatures[].custom.IMG_123.jpg.* signature | string | 
+*contentMetadata.validatedSignatures[].* provider | string | 
+*contentMetadata.validatedSignatures[].* publicKey | string | 
+timestamp | string | 
+
+### input-starling-capture-examples
+Name | Type | Description
+---- | ---- | -----------
+contentMetadata | object | 
+*contentMetadata.* author | object | 
+*contentMetadata.author.* identifier | string | 
+*contentMetadata.author.* name | string | 
+*contentMetadata.author.* type | string | 
+*contentMetadata.* dateCreated | string | 
+*contentMetadata.* description | string | 
+*contentMetadata.* extras | object | 
+*contentMetadata.extras.* caption | string | 
+*contentMetadata.* location | object | 
+*contentMetadata.location.* GPSLatitude | string | 
+*contentMetadata.location.* GPSLatitudeRef | string | 
+*contentMetadata.location.* GPSLongitude | string | 
+*contentMetadata.location.* GPSLongitudeRef | string | 
+*contentMetadata.location.* GPSTimeStamp | string | 
+*contentMetadata.location.* city | string | 
+*contentMetadata.location.* countryCode | string | 
+*contentMetadata.location.* countryName | string | 
+*contentMetadata.location.* provinceState | string | 
+*contentMetadata.location.* streetAddress | string | 
+*contentMetadata.* mime | string | 
+*contentMetadata.* name | string | 
+*contentMetadata.* private | object | 
+*contentMetadata.private.* meta | string | 
+*contentMetadata.private.* providerToken | object | 
+*contentMetadata.private.providerToken.* author | object | 
+*contentMetadata.private.providerToken.author.* identifier | string | 
+*contentMetadata.private.providerToken.author.* name | string | 
+*contentMetadata.private.providerToken.author.* type | string | 
+*contentMetadata.private.providerToken.* collection_id | string | 
+*contentMetadata.private.providerToken.* organization_id | string | 
+*contentMetadata.private.* signature | array | 
+*contentMetadata.private.* signature[] | object | 
+*contentMetadata.private.signature[].* proofHash | string | 
+*contentMetadata.private.signature[].* provider | string | 
+*contentMetadata.private.signature[].* publicKey | string | 
+*contentMetadata.private.signature[].* signature | string | 
+*contentMetadata.private.* targetProvider | string | 
+*contentMetadata.* validatedSignature | array | 
+*contentMetadata.* validatedSignature[] | object | 
+*contentMetadata.validatedSignature[].* algorithm | string | 
+*contentMetadata.validatedSignature[].* authenticatedMessage | string | 
+*contentMetadata.validatedSignature[].* authenticatedMessageDescription | string | 
+*contentMetadata.validatedSignature[].* provider | string | 
+*contentMetadata.validatedSignature[].* publicKey | string | 
+*contentMetadata.validatedSignature[].* signature | string | 
+timestamp | string | 
+
+## Meta recorder
+Name | Type | Description
+---- | ---- | -----------
+recorderMetadata | array | 
+recorderMetadata[] | object | 
+*recorderMetadata[].* info | array | 
+*recorderMetadata[].* info[] | object | 
+*recorderMetadata[].info[].* type | string | 
+*recorderMetadata[].info[].* values | object | 
+*recorderMetadata[].info[].values.* branch | string | *Optional* 
+*recorderMetadata[].info[].values.* clean | boolean | *Optional* 
+*recorderMetadata[].info[].values.* commit | string | *Optional* 
+*recorderMetadata[].info[].values.* image | string | *Optional* 
+*recorderMetadata[].info[].values.* name | string | *Optional* 
+*recorderMetadata[].info[].values.* repository | string | *Optional* 
+*recorderMetadata[].* service | string | 
+timestamp | string | 
+
+### input-archiveweb-examples
+Name | Type | Description
+---- | ---- | -----------
+recorderMetadata | array | 
+recorderMetadata[] | object | 
+*recorderMetadata[].* info | array | 
+*recorderMetadata[].* info[] | object | 
+*recorderMetadata[].info[].* type | string | 
+*recorderMetadata[].info[].* values | object | 
+*recorderMetadata[].info[].values.* branch | string | *Optional* 
+*recorderMetadata[].info[].values.* clean | boolean | *Optional* 
+*recorderMetadata[].info[].values.* commit | string | *Optional* 
+*recorderMetadata[].info[].values.* image | string | *Optional* 
+*recorderMetadata[].info[].values.* name | string | *Optional* 
+*recorderMetadata[].info[].values.* repository | string | *Optional* 
+*recorderMetadata[].* service | string | 
+timestamp | string | 
+
+### input-browsertrix-examples
+Name | Type | Description
+---- | ---- | -----------
+recorderMetadata | array | 
+recorderMetadata[] | object | 
+*recorderMetadata[].* info | array | 
+*recorderMetadata[].* info[] | object | 
+*recorderMetadata[].info[].* type | string | 
+*recorderMetadata[].info[].* values | object | 
+*recorderMetadata[].info[].values.* branch | string | *Optional* 
+*recorderMetadata[].info[].values.* clean | boolean | *Optional* 
+*recorderMetadata[].info[].values.* commit | string | *Optional* 
+*recorderMetadata[].info[].values.* image | string | *Optional* 
+*recorderMetadata[].info[].values.* name | string | *Optional* 
+*recorderMetadata[].info[].values.* repository | string | *Optional* 
+*recorderMetadata[].* service | string | 
+timestamp | string | 
+
+### input-chatbot-examples
+Name | Type | Description
+---- | ---- | -----------
+recorderMetadata | array | 
+recorderMetadata[] | object | 
+*recorderMetadata[].* info | array | 
+*recorderMetadata[].* info[] | object | 
+*recorderMetadata[].info[].* type | string | 
+*recorderMetadata[].info[].* values | object | 
+*recorderMetadata[].info[].values.* branch | string | *Optional* 
+*recorderMetadata[].info[].values.* clean | boolean | *Optional* 
+*recorderMetadata[].info[].values.* commit | string | *Optional* 
+*recorderMetadata[].info[].values.* image | string | *Optional* 
+*recorderMetadata[].info[].values.* name | string | *Optional* 
+*recorderMetadata[].info[].values.* repository | string | *Optional* 
+*recorderMetadata[].* service | string | 
+timestamp | string | 
+
+### input-dropbox-examples
+Name | Type | Description
+---- | ---- | -----------
+recorderMetadata | array | 
+recorderMetadata[] | object | 
+*recorderMetadata[].* info | array | 
+*recorderMetadata[].* info[] | object | 
+*recorderMetadata[].info[].* type | string | 
+*recorderMetadata[].info[].* values | object | 
+*recorderMetadata[].info[].values.* branch | string | *Optional* 
+*recorderMetadata[].info[].values.* clean | boolean | *Optional* 
+*recorderMetadata[].info[].values.* commit | string | *Optional* 
+*recorderMetadata[].info[].values.* image | string | *Optional* 
+*recorderMetadata[].info[].values.* name | string | *Optional* 
+*recorderMetadata[].info[].values.* repository | string | *Optional* 
+*recorderMetadata[].* service | string | 
+timestamp | string | 
+
+### input-proofmode-signal-examples
+Name | Type | Description
+---- | ---- | -----------
+recorderMetadata | array | 
+recorderMetadata[] | object | 
+*recorderMetadata[].* info | array | 
+*recorderMetadata[].* info[] | object | 
+*recorderMetadata[].info[].* type | string | 
+*recorderMetadata[].info[].* values | object | 
+*recorderMetadata[].info[].values.* branch | string | *Optional* 
+*recorderMetadata[].info[].values.* clean | boolean | *Optional* 
+*recorderMetadata[].info[].values.* commit | string | *Optional* 
+*recorderMetadata[].info[].values.* image | string | *Optional* 
+*recorderMetadata[].info[].values.* name | string | *Optional* 
+*recorderMetadata[].info[].values.* repository | string | *Optional* 
+*recorderMetadata[].* service | string | 
+timestamp | string | 
+
+### input-starling-capture-examples
+Name | Type | Description
+---- | ---- | -----------
+recorderMetadata | array | 
+recorderMetadata[] | object | 
+*recorderMetadata[].* info | array | 
+*recorderMetadata[].* info[] | object | 
+*recorderMetadata[].info[].* type | string | 
+*recorderMetadata[].info[].* values | object | 
+*recorderMetadata[].info[].values.* branch | string | *Optional* 
+*recorderMetadata[].info[].values.* clean | boolean | *Optional* 
+*recorderMetadata[].info[].values.* commit | string | *Optional* 
+*recorderMetadata[].info[].values.* name | string | *Optional* 
+*recorderMetadata[].info[].values.* repository | string | *Optional* 
+*recorderMetadata[].* service | string | 
+timestamp | string | 

--- a/integrity-backend/README.md
+++ b/integrity-backend/README.md
@@ -35,8 +35,6 @@ contentMetadata | object |
 *contentMetadata.extras.* localsignSignature | string | *Optional* 
 *contentMetadata.extras.* localsignSoftware | string | *Optional* 
 *contentMetadata.extras.* pages | object | *Optional* 
-*contentMetadata.extras.pages.* 5ZwqT9xGkYVdYku3EVQLrD | string | *Optional* 
-*contentMetadata.extras.pages.* vngimrkldkpt682awhwrb | string | *Optional* 
 *contentMetadata.extras.* software | string | *Optional* 
 *contentMetadata.extras.* waczTitle | string | *Optional* 
 *contentMetadata.extras.* waczVersion | string | *Optional* 
@@ -115,43 +113,6 @@ contentMetadata | object |
 *contentMetadata.private.crawlData.* watchIPs | array\<string\> | 
 *contentMetadata.private.* meta | string | *Optional* 
 *contentMetadata.private.* proofmode | object | *Optional* 
-*contentMetadata.private.proofmode.* 20220608_162522.jpg | object | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.* dateCreate | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.* pgpPublicKey | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.* pgpSignature | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.* proofmodeJSON | object | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* CellInfo | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* DataType | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* DeviceID | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* File Hash SHA256 | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* File Modified | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* File Path | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Hardware | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* IPv4 | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* IPv6 | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Language | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Locale | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Location.Accuracy | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Location.Altitude | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Location.Bearing | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Location.Latitude | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Location.Longitude | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Location.Provider | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Location.Speed | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Location.Time | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Manufacturer | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Network | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* NetworkType | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Notes | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Proof Generated | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* SafetyCheck | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* SafetyCheckBasicIntegrity | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* SafetyCheckCtsMatch | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* SafetyCheckTimestamp | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* ScreenSize | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Wifi MAC | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.* sha256hash | string | 
-*contentMetadata.private.proofmode.* dateCreate | string | 
 *contentMetadata.private.* providerToken | object | *Optional* 
 *contentMetadata.private.providerToken.* author | object | 
 *contentMetadata.private.providerToken.author.* identifier | string | 
@@ -210,23 +171,15 @@ contentMetadata | object |
 *contentMetadata.validatedSignatures[].* authenticatedMessage | string | *Optional* 
 *contentMetadata.validatedSignatures[].* authenticatedMessageDescription | string | *Optional* 
 *contentMetadata.validatedSignatures[].* custom | object | *Optional* 
-*contentMetadata.validatedSignatures[].custom.* 8045cb0d6783638e5828f3cca0ec3aab6ab5b9f8a971faf620a58f6cee1c7ca8.proof.csv | object | *Optional* 
-*contentMetadata.validatedSignatures[].custom.8045cb0d6783638e5828f3cca0ec3aab6ab5b9f8a971faf620a58f6cee1c7ca8.proof.csv.* authenticatedMessage | string | 
-*contentMetadata.validatedSignatures[].custom.8045cb0d6783638e5828f3cca0ec3aab6ab5b9f8a971faf620a58f6cee1c7ca8.proof.csv.* authenticatedMessageDescription | string | 
-*contentMetadata.validatedSignatures[].custom.8045cb0d6783638e5828f3cca0ec3aab6ab5b9f8a971faf620a58f6cee1c7ca8.proof.csv.* signature | string | 
-*contentMetadata.validatedSignatures[].custom.* IMG_123.jpg | object | *Optional* 
-*contentMetadata.validatedSignatures[].custom.IMG_123.jpg.* authenticatedMessage | string | 
-*contentMetadata.validatedSignatures[].custom.IMG_123.jpg.* authenticatedMessageDescription | string | 
-*contentMetadata.validatedSignatures[].custom.IMG_123.jpg.* signature | string | 
-*contentMetadata.validatedSignatures[].custom.* created | string | *Optional* 
-*contentMetadata.validatedSignatures[].custom.* domain | string | *Optional* 
-*contentMetadata.validatedSignatures[].custom.* domainCert | string | *Optional* 
-*contentMetadata.validatedSignatures[].custom.* hash | string | *Optional* 
-*contentMetadata.validatedSignatures[].custom.* signature | string | *Optional* 
-*contentMetadata.validatedSignatures[].custom.* software | string | *Optional* 
-*contentMetadata.validatedSignatures[].custom.* timeSignature | string | *Optional* 
-*contentMetadata.validatedSignatures[].custom.* timestampCert | string | *Optional* 
-*contentMetadata.validatedSignatures[].custom.* version | string | *Optional* 
+*contentMetadata.validatedSignatures[].custom.* created | string | 
+*contentMetadata.validatedSignatures[].custom.* domain | string | 
+*contentMetadata.validatedSignatures[].custom.* domainCert | string | 
+*contentMetadata.validatedSignatures[].custom.* hash | string | 
+*contentMetadata.validatedSignatures[].custom.* signature | string | 
+*contentMetadata.validatedSignatures[].custom.* software | string | 
+*contentMetadata.validatedSignatures[].custom.* timeSignature | string | 
+*contentMetadata.validatedSignatures[].custom.* timestampCert | string | 
+*contentMetadata.validatedSignatures[].custom.* version | string | 
 *contentMetadata.validatedSignatures[].* publicKey | string | *Optional* 
 *contentMetadata.validatedSignatures[].* signature | string | *Optional* 
 sourceId | object | *Optional* 
@@ -250,7 +203,6 @@ contentMetadata | object |
 *contentMetadata.extras.* localsignSignature | string | 
 *contentMetadata.extras.* localsignSoftware | string | 
 *contentMetadata.extras.* pages | object | 
-*contentMetadata.extras.pages.* vngimrkldkpt682awhwrb | string | 
 *contentMetadata.extras.* software | string | 
 *contentMetadata.extras.* waczTitle | string | 
 *contentMetadata.extras.* waczVersion | string | 
@@ -284,7 +236,6 @@ contentMetadata | object |
 *contentMetadata.extras.* authsignDomain | string | 
 *contentMetadata.extras.* authsignSoftware | string | 
 *contentMetadata.extras.* pages | object | 
-*contentMetadata.extras.pages.* 5ZwqT9xGkYVdYku3EVQLrD | string | 
 *contentMetadata.extras.* waczVersion | string | 
 *contentMetadata.* mime | string | 
 *contentMetadata.* name | string | 
@@ -443,43 +394,6 @@ contentMetadata | object |
 *contentMetadata.* name | string | 
 *contentMetadata.* private | object | 
 *contentMetadata.private.* proofmode | object | 
-*contentMetadata.private.proofmode.* 20220608_162522.jpg | object | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.* dateCreate | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.* pgpPublicKey | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.* pgpSignature | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.* proofmodeJSON | object | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* CellInfo | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* DataType | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* DeviceID | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* File Hash SHA256 | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* File Modified | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* File Path | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Hardware | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* IPv4 | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* IPv6 | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Language | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Locale | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Location.Accuracy | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Location.Altitude | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Location.Bearing | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Location.Latitude | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Location.Longitude | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Location.Provider | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Location.Speed | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Location.Time | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Manufacturer | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Network | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* NetworkType | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Notes | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Proof Generated | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* SafetyCheck | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* SafetyCheckBasicIntegrity | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* SafetyCheckCtsMatch | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* SafetyCheckTimestamp | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* ScreenSize | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.proofmodeJSON.* Wifi MAC | string | 
-*contentMetadata.private.proofmode.20220608_162522.jpg.* sha256hash | string | 
-*contentMetadata.private.proofmode.* dateCreate | string | 
 *contentMetadata.private.* signal | object | 
 *contentMetadata.private.signal.* body | string | 
 *contentMetadata.private.signal.* source | string | 
@@ -492,14 +406,6 @@ contentMetadata | object |
 *contentMetadata.* validatedSignatures[] | object | 
 *contentMetadata.validatedSignatures[].* algorithm | string | 
 *contentMetadata.validatedSignatures[].* custom | object | 
-*contentMetadata.validatedSignatures[].custom.* 8045cb0d6783638e5828f3cca0ec3aab6ab5b9f8a971faf620a58f6cee1c7ca8.proof.csv | object | 
-*contentMetadata.validatedSignatures[].custom.8045cb0d6783638e5828f3cca0ec3aab6ab5b9f8a971faf620a58f6cee1c7ca8.proof.csv.* authenticatedMessage | string | 
-*contentMetadata.validatedSignatures[].custom.8045cb0d6783638e5828f3cca0ec3aab6ab5b9f8a971faf620a58f6cee1c7ca8.proof.csv.* authenticatedMessageDescription | string | 
-*contentMetadata.validatedSignatures[].custom.8045cb0d6783638e5828f3cca0ec3aab6ab5b9f8a971faf620a58f6cee1c7ca8.proof.csv.* signature | string | 
-*contentMetadata.validatedSignatures[].custom.* IMG_123.jpg | object | 
-*contentMetadata.validatedSignatures[].custom.IMG_123.jpg.* authenticatedMessage | string | 
-*contentMetadata.validatedSignatures[].custom.IMG_123.jpg.* authenticatedMessageDescription | string | 
-*contentMetadata.validatedSignatures[].custom.IMG_123.jpg.* signature | string | 
 *contentMetadata.validatedSignatures[].* provider | string | 
 *contentMetadata.validatedSignatures[].* publicKey | string | 
 timestamp | string | 

--- a/integrity-backend/TODO.md
+++ b/integrity-backend/TODO.md
@@ -1,1 +1,2 @@
 - [ ] add `patternProperties` handling to `json-schema-to-markdown` (right now, they're ignored)
+- [ ] provide better types for fields currently listed as `null`

--- a/integrity-backend/TODO.md
+++ b/integrity-backend/TODO.md
@@ -1,0 +1,1 @@
+- [ ] add `patternProperties` handling to `json-schema-to-markdown` (right now, they're ignored)

--- a/integrity-backend/generate-joint-json-schemas.sh
+++ b/integrity-backend/generate-joint-json-schemas.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+if ! which genson &> /dev/null; then
+  echo 'genson (https://pypi.org/project/genson/) not found'
+  echo 'Please install genson: pip install genson'
+  exit 1
+fi
+
+if ! which jq &> /dev/null; then
+  echo 'jq (https://stedolan.github.io/jq/) not found'
+  echo 'Please install jq: https://stedolan.github.io/jq/download/'
+  exit 1
+fi
+
+echo 'Generating joint JSON schema for meta content'
+
+args=''
+for f in ./*/meta-content.schema.json; do
+  args="$args -s $f"
+done
+genson $args | jq > meta-content.schema.json
+
+echo 'Generating joint JSON schema for meta recorder'
+
+args=''
+for f in ./*/meta-recorder.schema.json; do
+  args="$args -s $f"
+done
+genson $args | jq > meta-recorder.schema.json

--- a/integrity-backend/generate-json-schemas.sh
+++ b/integrity-backend/generate-json-schemas.sh
@@ -16,17 +16,13 @@ echo 'Generating JSON schema for validated signatures'
 genson sig66_validated_signatures.json | jq > sig66_validated_signatures.schema.json
 
 echo 'Generating JSON schemas for meta content per input type'
-for f in **/*-meta-content.json; do
-    genson $f | jq > $(dirname $f)/meta-content.schema.json
+for f in ./*/*-meta-content.json; do
+  genson $f | jq > $(dirname $f)/meta-content.schema.json
 done
-
-echo 'Generating joint JSON schema for meta content'
-genson **/*-meta-content.json | jq > meta-content.schema.json
 
 echo 'Generating JSON schemas for meta recorder per input type'
-for f in **/*-meta-recorder.json; do
-    genson $f | jq > $(dirname $f)/meta-recorder.schema.json
+for f in ./*/*-meta-recorder.json; do
+  genson $f | jq > $(dirname $f)/meta-recorder.schema.json
 done
 
-echo 'Generating joint JSON schema for meta recorder'
-genson **/*-meta-recorder.json | jq > meta-recorder.schema.json
+./generate-joint-json-schemas.sh

--- a/integrity-backend/generate-json-schemas.sh
+++ b/integrity-backend/generate-json-schemas.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+if ! which genson &> /dev/null; then
+  echo 'genson (https://pypi.org/project/genson/) not found'
+  echo 'Please install genson: pip install genson'
+  exit 1
+fi
+
+if ! which jq &> /dev/null; then
+  echo 'jq (https://stedolan.github.io/jq/) not found'
+  echo 'Please install jq: https://stedolan.github.io/jq/download/'
+  exit 1
+fi
+
+echo 'Generating JSON schema for validated signatures'
+genson sig66_validated_signatures.json | jq > sig66_validated_signatures.schema.json
+
+echo 'Generating JSON schemas for meta content per input type'
+for f in **/*-meta-content.json; do
+    genson $f | jq > $(dirname $f)/meta-content.schema.json
+done
+
+echo 'Generating joint JSON schema for meta content'
+genson **/*-meta-content.json | jq > meta-content.schema.json
+
+echo 'Generating JSON schemas for meta recorder per input type'
+for f in **/*-meta-recorder.json; do
+    genson $f | jq > $(dirname $f)/meta-recorder.schema.json
+done
+
+echo 'Generating joint JSON schema for meta recorder'
+genson **/*-meta-recorder.json | jq > meta-recorder.schema.json

--- a/integrity-backend/generate-readme.sh
+++ b/integrity-backend/generate-readme.sh
@@ -7,14 +7,31 @@ if ! which json-schema-to-markdown &> /dev/null; then
 fi
 
 echo '# Schemas' > README.md
+
+echo '' >> README.md
+echo '## Table of contents' >> README.md
+echo '' >> README.md
+
+echo '- [Validated signatures](#validated-signatures)' >> README.md
+echo '- [Meta content](#meta-content)' >> README.md
+for f in **/meta-content.schema.json; do
+  echo "    - [$(basename $(dirname $f))](#$(basename $(dirname $f)))" >> README.md
+done
+echo '- [Meta recorder](#meta-recorder)' >> README.md
+for f in **/meta-recorder.schema.json; do
+  echo "    - [$(basename $(dirname $f))](#$(basename $(dirname $f)))" >> README.md
+done
+
 echo '' >> README.md
 echo '## Validated signatures' >> README.md
+echo '' >> README.md
 
 echo 'Generating markdown for validated signatures'
 json-schema-to-markdown sig66_validated_signatures.schema.json >> README.md
 
 echo '' >> README.md
 echo '## Meta content' >> README.md
+echo '' >> README.md
 
 echo 'Generating markdown for meta content'
 json-schema-to-markdown meta-content.schema.json >> README.md
@@ -30,6 +47,7 @@ done
 
 echo '' >> README.md
 echo '## Meta recorder' >> README.md
+echo '' >> README.md
 
 echo 'Generating markdown for meta recorder'
 json-schema-to-markdown meta-recorder.schema.json >> README.md

--- a/integrity-backend/generate-readme.sh
+++ b/integrity-backend/generate-readme.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+if ! which json-schema-to-markdown &> /dev/null; then
+  echo 'json-schema-to-markdown (https://www.npmjs.com/package/json-schema-to-markdown-table) not found'
+  echo 'Please install json-schema-to-markdown: npm install -g json-schema-to-markdown-table'
+  exit 1
+fi
+
+echo '# Schemas' > README.md
+echo '' >> README.md
+echo '## Validated signatures' >> README.md
+
+echo 'Generating markdown for validated signatures'
+json-schema-to-markdown sig66_validated_signatures.schema.json >> README.md
+
+echo '' >> README.md
+echo '## Meta content' >> README.md
+
+echo 'Generating markdown for meta content'
+json-schema-to-markdown meta-content.schema.json >> README.md
+
+echo 'Generating markdown for meta content per input type'
+for f in **/meta-content.schema.json; do
+    echo '' >> README.md
+    echo "### $(basename $(dirname $f))" >> README.md
+
+    echo $f
+    json-schema-to-markdown $f >> README.md
+done
+
+echo '' >> README.md
+echo '## Meta recorder' >> README.md
+
+echo 'Generating markdown for meta recorder'
+json-schema-to-markdown meta-recorder.schema.json >> README.md
+
+echo 'Generating markdown for meta recorder per input type'
+for f in **/meta-recorder.schema.json; do
+    echo '' >> README.md
+    echo "### $(basename $(dirname $f))" >> README.md
+    json-schema-to-markdown $f >> README.md
+done

--- a/integrity-backend/input-archiveweb-examples/meta-content.schema.json
+++ b/integrity-backend/input-archiveweb-examples/meta-content.schema.json
@@ -1,0 +1,159 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "contentMetadata": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "mime": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "author": {
+          "type": "object",
+          "properties": {
+            "@type": {
+              "type": "string"
+            },
+            "identifier": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "@type",
+            "identifier",
+            "name"
+          ]
+        },
+        "dateCreated": {
+          "type": "string"
+        },
+        "extras": {
+          "type": "object",
+          "properties": {
+            "localsignSoftware": {
+              "type": "string"
+            },
+            "localsignPublicKey": {
+              "type": "string"
+            },
+            "localsignSignature": {
+              "type": "string"
+            },
+            "waczTitle": {
+              "type": "string"
+            },
+            "waczVersion": {
+              "type": "string"
+            },
+            "software": {
+              "type": "string"
+            },
+            "dateCrawled": {
+              "type": "string"
+            },
+            "pages": {
+              "type": "object",
+              "properties": {
+                "vngimrkldkpt682awhwrb": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "vngimrkldkpt682awhwrb"
+              ]
+            }
+          },
+          "required": [
+            "dateCrawled",
+            "localsignPublicKey",
+            "localsignSignature",
+            "localsignSoftware",
+            "pages",
+            "software",
+            "waczTitle",
+            "waczVersion"
+          ]
+        },
+        "validatedSignatures": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "provider": {
+                "type": "string"
+              },
+              "algorithm": {
+                "type": "string"
+              },
+              "publicKey": {
+                "type": "string"
+              },
+              "signature": {
+                "type": "string"
+              },
+              "authenticatedMessage": {
+                "type": "string"
+              },
+              "authenticatedMessageDescription": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "algorithm",
+              "authenticatedMessage",
+              "authenticatedMessageDescription",
+              "provider",
+              "publicKey",
+              "signature"
+            ]
+          }
+        },
+        "private": {
+          "type": "object",
+          "properties": {
+            "uploaderName": {
+              "type": "string"
+            },
+            "uploadFilename": {
+              "type": "string"
+            },
+            "uploadDirectory": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "uploadDirectory",
+            "uploadFilename",
+            "uploaderName"
+          ]
+        },
+        "timestamp": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "author",
+        "dateCreated",
+        "description",
+        "extras",
+        "mime",
+        "name",
+        "private",
+        "timestamp",
+        "validatedSignatures"
+      ]
+    }
+  },
+  "required": [
+    "contentMetadata"
+  ]
+}

--- a/integrity-backend/input-archiveweb-examples/meta-content.schema.json
+++ b/integrity-backend/input-archiveweb-examples/meta-content.schema.json
@@ -62,14 +62,11 @@
             },
             "pages": {
               "type": "object",
-              "properties": {
-                "vngimrkldkpt682awhwrb": {
+              "patternProperties": {
+                "^.+$": {
                   "type": "string"
                 }
-              },
-              "required": [
-                "vngimrkldkpt682awhwrb"
-              ]
+              }
             }
           },
           "required": [

--- a/integrity-backend/input-archiveweb-examples/meta-recorder.schema.json
+++ b/integrity-backend/input-archiveweb-examples/meta-recorder.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "recorderMetadata": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "service": {
+            "type": "string"
+          },
+          "info": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                },
+                "values": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "image": {
+                      "type": "string"
+                    },
+                    "repository": {
+                      "type": "string"
+                    },
+                    "branch": {
+                      "type": "string"
+                    },
+                    "commit": {
+                      "type": "string"
+                    },
+                    "clean": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              },
+              "required": [
+                "type",
+                "values"
+              ]
+            }
+          }
+        },
+        "required": [
+          "info",
+          "service"
+        ]
+      }
+    },
+    "timestamp": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "recorderMetadata",
+    "timestamp"
+  ]
+}

--- a/integrity-backend/input-browsertrix-examples/TODO.md
+++ b/integrity-backend/input-browsertrix-examples/TODO.md
@@ -1,0 +1,6 @@
+- [ ] Update the `3e11cc57daf3bad8375935cad4878123acc8d769551ff90f1b1bb0dc597-meta-content.json` example in a way which would allow infering item types for the following arrays:
+    - [ ] `files`
+    - [ ] `colls`
+    - [ ] `files`
+    - [ ] `watchIPs`
+    - [ ] `all_codes`

--- a/integrity-backend/input-browsertrix-examples/meta-content.schema.json
+++ b/integrity-backend/input-browsertrix-examples/meta-content.schema.json
@@ -214,7 +214,10 @@
                   "type": "string"
                 },
                 "colls": {
-                  "type": "array"
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
                 },
                 "crawlTimeout": {
                   "type": "integer"
@@ -327,10 +330,16 @@
                   ]
                 },
                 "files": {
-                  "type": "array"
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
                 },
                 "colls": {
-                  "type": "array"
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
                 },
                 "userName": {
                   "type": "string"
@@ -365,7 +374,10 @@
                   }
                 },
                 "watchIPs": {
-                  "type": "array"
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
                 }
               },
               "required": [
@@ -437,7 +449,10 @@
                   }
                 },
                 "all_codes": {
-                  "type": "array"
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
                 }
               },
               "required": [

--- a/integrity-backend/input-browsertrix-examples/meta-content.schema.json
+++ b/integrity-backend/input-browsertrix-examples/meta-content.schema.json
@@ -1,0 +1,499 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "contentMetadata": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "mime": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "author": {
+          "type": "object",
+          "properties": {
+            "@type": {
+              "type": "string"
+            },
+            "identifier": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "@type",
+            "identifier",
+            "name"
+          ]
+        },
+        "dateCreated": {
+          "type": "string"
+        },
+        "extras": {
+          "type": "object",
+          "properties": {
+            "authsignSoftware": {
+              "type": "string"
+            },
+            "authsignDomain": {
+              "type": "string"
+            },
+            "waczVersion": {
+              "type": "string"
+            },
+            "pages": {
+              "type": "object",
+              "properties": {
+                "5ZwqT9xGkYVdYku3EVQLrD": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "5ZwqT9xGkYVdYku3EVQLrD"
+              ]
+            }
+          },
+          "required": [
+            "authsignDomain",
+            "authsignSoftware",
+            "pages",
+            "waczVersion"
+          ]
+        },
+        "validatedSignatures": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "provider": {
+                "type": "string"
+              },
+              "algorithm": {
+                "type": "string"
+              },
+              "custom": {
+                "type": "object",
+                "properties": {
+                  "hash": {
+                    "type": "string"
+                  },
+                  "created": {
+                    "type": "string"
+                  },
+                  "software": {
+                    "type": "string"
+                  },
+                  "signature": {
+                    "type": "string"
+                  },
+                  "domain": {
+                    "type": "string"
+                  },
+                  "domainCert": {
+                    "type": "string"
+                  },
+                  "timeSignature": {
+                    "type": "string"
+                  },
+                  "timestampCert": {
+                    "type": "string"
+                  },
+                  "version": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "created",
+                  "domain",
+                  "domainCert",
+                  "hash",
+                  "signature",
+                  "software",
+                  "timeSignature",
+                  "timestampCert",
+                  "version"
+                ]
+              }
+            },
+            "required": [
+              "algorithm",
+              "custom",
+              "provider"
+            ]
+          }
+        },
+        "private": {
+          "type": "object",
+          "properties": {
+            "crawlConfigs": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "schedule": {
+                  "type": "string"
+                },
+                "config": {
+                  "type": "object",
+                  "properties": {
+                    "seeds": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "scopeType": {
+                      "type": "string"
+                    },
+                    "include": {
+                      "type": "null"
+                    },
+                    "exclude": {
+                      "type": "null"
+                    },
+                    "depth": {
+                      "type": "integer"
+                    },
+                    "limit": {
+                      "type": "integer"
+                    },
+                    "extraHops": {
+                      "type": "integer"
+                    },
+                    "behaviorTimeout": {
+                      "type": "null"
+                    },
+                    "workers": {
+                      "type": "null"
+                    },
+                    "headless": {
+                      "type": "null"
+                    },
+                    "generateWACZ": {
+                      "type": "null"
+                    },
+                    "combineWARC": {
+                      "type": "null"
+                    },
+                    "logging": {
+                      "type": "null"
+                    },
+                    "behaviors": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "behaviorTimeout",
+                    "behaviors",
+                    "combineWARC",
+                    "depth",
+                    "exclude",
+                    "extraHops",
+                    "generateWACZ",
+                    "headless",
+                    "include",
+                    "limit",
+                    "logging",
+                    "scopeType",
+                    "seeds",
+                    "workers"
+                  ]
+                },
+                "name": {
+                  "type": "string"
+                },
+                "created": {
+                  "type": "string"
+                },
+                "colls": {
+                  "type": "array"
+                },
+                "crawlTimeout": {
+                  "type": "integer"
+                },
+                "scale": {
+                  "type": "integer"
+                },
+                "aid": {
+                  "type": "string"
+                },
+                "userid": {
+                  "type": "string"
+                },
+                "crawlCount": {
+                  "type": "integer"
+                },
+                "lastCrawlId": {
+                  "type": "string"
+                },
+                "lastCrawlTime": {
+                  "type": "string"
+                },
+                "lastCrawlState": {
+                  "type": "string"
+                },
+                "newId": {
+                  "type": "null"
+                },
+                "oldId": {
+                  "type": "null"
+                },
+                "inactive": {
+                  "type": "boolean"
+                },
+                "currCrawlId": {
+                  "type": "null"
+                },
+                "userName": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "aid",
+                "colls",
+                "config",
+                "crawlCount",
+                "crawlTimeout",
+                "created",
+                "currCrawlId",
+                "id",
+                "inactive",
+                "lastCrawlId",
+                "lastCrawlState",
+                "lastCrawlTime",
+                "name",
+                "newId",
+                "oldId",
+                "scale",
+                "schedule",
+                "userName",
+                "userid"
+              ]
+            },
+            "crawlData": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "userid": {
+                  "type": "string"
+                },
+                "aid": {
+                  "type": "string"
+                },
+                "cid": {
+                  "type": "string"
+                },
+                "manual": {
+                  "type": "boolean"
+                },
+                "started": {
+                  "type": "string"
+                },
+                "finished": {
+                  "type": "string"
+                },
+                "state": {
+                  "type": "string"
+                },
+                "scale": {
+                  "type": "integer"
+                },
+                "completions": {
+                  "type": "integer"
+                },
+                "stats": {
+                  "type": "object",
+                  "properties": {
+                    "done": {
+                      "type": "string"
+                    },
+                    "found": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "done",
+                    "found"
+                  ]
+                },
+                "files": {
+                  "type": "array"
+                },
+                "colls": {
+                  "type": "array"
+                },
+                "userName": {
+                  "type": "string"
+                },
+                "configName": {
+                  "type": "string"
+                },
+                "resources": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "path": {
+                        "type": "string"
+                      },
+                      "hash": {
+                        "type": "string"
+                      },
+                      "size": {
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "hash",
+                      "name",
+                      "path",
+                      "size"
+                    ]
+                  }
+                },
+                "watchIPs": {
+                  "type": "array"
+                }
+              },
+              "required": [
+                "aid",
+                "cid",
+                "colls",
+                "completions",
+                "configName",
+                "files",
+                "finished",
+                "id",
+                "manual",
+                "resources",
+                "scale",
+                "started",
+                "state",
+                "stats",
+                "userName",
+                "userid",
+                "watchIPs"
+              ]
+            },
+            "additionalData": {
+              "type": "object",
+              "properties": {
+                "url_list": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "thread_ts": {
+                  "type": "string"
+                },
+                "ts": {
+                  "type": "string"
+                },
+                "client_msg_id": {
+                  "type": "string"
+                },
+                "attached_service": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "attached_ts": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  }
+                },
+                "attached_author": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "attached_text": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "country_codes": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "all_codes": {
+                  "type": "array"
+                }
+              },
+              "required": [
+                "all_codes",
+                "attached_author",
+                "attached_service",
+                "attached_text",
+                "attached_ts",
+                "client_msg_id",
+                "country_codes",
+                "thread_ts",
+                "ts",
+                "url_list"
+              ]
+            }
+          },
+          "required": [
+            "additionalData",
+            "crawlConfigs",
+            "crawlData"
+          ]
+        }
+      },
+      "required": [
+        "author",
+        "dateCreated",
+        "description",
+        "extras",
+        "mime",
+        "name",
+        "private",
+        "validatedSignatures"
+      ]
+    },
+    "sourceId": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "key",
+        "value"
+      ]
+    },
+    "timestamp": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "contentMetadata",
+    "sourceId",
+    "timestamp"
+  ]
+}

--- a/integrity-backend/input-browsertrix-examples/meta-content.schema.json
+++ b/integrity-backend/input-browsertrix-examples/meta-content.schema.json
@@ -50,14 +50,11 @@
             },
             "pages": {
               "type": "object",
-              "properties": {
-                "5ZwqT9xGkYVdYku3EVQLrD": {
+              "patternProperties": {
+                "^.+$": {
                   "type": "string"
                 }
-              },
-              "required": [
-                "5ZwqT9xGkYVdYku3EVQLrD"
-              ]
+              }
             }
           },
           "required": [

--- a/integrity-backend/input-browsertrix-examples/meta-recorder.schema.json
+++ b/integrity-backend/input-browsertrix-examples/meta-recorder.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "recorderMetadata": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "service": {
+            "type": "string"
+          },
+          "info": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                },
+                "values": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "image": {
+                      "type": "string"
+                    },
+                    "repository": {
+                      "type": "string"
+                    },
+                    "branch": {
+                      "type": "string"
+                    },
+                    "commit": {
+                      "type": "string"
+                    },
+                    "clean": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              },
+              "required": [
+                "type",
+                "values"
+              ]
+            }
+          }
+        },
+        "required": [
+          "info",
+          "service"
+        ]
+      }
+    },
+    "timestamp": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "recorderMetadata",
+    "timestamp"
+  ]
+}

--- a/integrity-backend/input-chatbot-examples/meta-content.schema.json
+++ b/integrity-backend/input-chatbot-examples/meta-content.schema.json
@@ -1,0 +1,135 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "contentMetadata": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "mime": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "author": {
+          "type": "object",
+          "properties": {
+            "@type": {
+              "type": "string"
+            },
+            "identifier": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "@type",
+            "identifier",
+            "name"
+          ]
+        },
+        "dateCreated": {
+          "type": "string"
+        },
+        "extras": {
+          "type": "object",
+          "properties": {
+            "channels": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "dateRage": {
+              "type": "object",
+              "properties": {
+                "from": {
+                  "type": "string"
+                },
+                "to": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "from",
+                "to"
+              ]
+            }
+          },
+          "required": [
+            "channels",
+            "dateRage"
+          ]
+        },
+        "private": {
+          "type": "object",
+          "properties": {
+            "signal": {
+              "type": "object",
+              "properties": {
+                "phoneNumber": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "phoneNumber"
+              ]
+            },
+            "slack": {
+              "type": "object",
+              "properties": {
+                "botAccount": {
+                  "type": "string"
+                },
+                "workspace": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "botAccount",
+                "workspace"
+              ]
+            },
+            "telegram": {
+              "type": "object",
+              "properties": {
+                "botAccount": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "botAccount"
+              ]
+            }
+          },
+          "required": [
+            "signal",
+            "slack",
+            "telegram"
+          ]
+        }
+      },
+      "required": [
+        "author",
+        "dateCreated",
+        "description",
+        "extras",
+        "mime",
+        "name",
+        "private"
+      ]
+    },
+    "timestamp": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "contentMetadata",
+    "timestamp"
+  ]
+}

--- a/integrity-backend/input-chatbot-examples/meta-recorder.schema.json
+++ b/integrity-backend/input-chatbot-examples/meta-recorder.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "recorderMetadata": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "service": {
+            "type": "string"
+          },
+          "info": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                },
+                "values": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "image": {
+                      "type": "string"
+                    },
+                    "repository": {
+                      "type": "string"
+                    },
+                    "branch": {
+                      "type": "string"
+                    },
+                    "commit": {
+                      "type": "string"
+                    },
+                    "clean": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              },
+              "required": [
+                "type",
+                "values"
+              ]
+            }
+          }
+        },
+        "required": [
+          "info",
+          "service"
+        ]
+      }
+    },
+    "timestamp": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "recorderMetadata",
+    "timestamp"
+  ]
+}

--- a/integrity-backend/input-dropbox-examples/meta-content.schema.json
+++ b/integrity-backend/input-dropbox-examples/meta-content.schema.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "contentMetadata": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "mime": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "author": {
+          "type": "object",
+          "properties": {
+            "@type": {
+              "type": "string"
+            },
+            "identifier": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "@type",
+            "identifier",
+            "name"
+          ]
+        },
+        "dateCreated": {
+          "type": "string"
+        },
+        "extras": {
+          "type": "object"
+        },
+        "private": {
+          "type": "object",
+          "properties": {
+            "uploaderName": {
+              "type": "string"
+            },
+            "uploadFilename": {
+              "type": "string"
+            },
+            "uploadDirectory": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "uploadDirectory",
+            "uploadFilename",
+            "uploaderName"
+          ]
+        }
+      },
+      "required": [
+        "author",
+        "dateCreated",
+        "description",
+        "extras",
+        "mime",
+        "name",
+        "private"
+      ]
+    },
+    "timestamp": {
+      "type": "string"
+    },
+    "sourceId": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "key",
+        "value"
+      ]
+    }
+  },
+  "required": [
+    "contentMetadata",
+    "sourceId",
+    "timestamp"
+  ]
+}

--- a/integrity-backend/input-dropbox-examples/meta-recorder.schema.json
+++ b/integrity-backend/input-dropbox-examples/meta-recorder.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "recorderMetadata": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "service": {
+            "type": "string"
+          },
+          "info": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                },
+                "values": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "image": {
+                      "type": "string"
+                    },
+                    "repository": {
+                      "type": "string"
+                    },
+                    "branch": {
+                      "type": "string"
+                    },
+                    "commit": {
+                      "type": "string"
+                    },
+                    "clean": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              },
+              "required": [
+                "type",
+                "values"
+              ]
+            }
+          }
+        },
+        "required": [
+          "info",
+          "service"
+        ]
+      }
+    },
+    "timestamp": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "recorderMetadata",
+    "timestamp"
+  ]
+}

--- a/integrity-backend/input-proofmode-signal-examples/meta-content.schema.json
+++ b/integrity-backend/input-proofmode-signal-examples/meta-content.schema.json
@@ -1,0 +1,347 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "contentMetadata": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "mime": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "author": {
+          "type": "object",
+          "properties": {
+            "@type": {
+              "type": "string"
+            },
+            "identifier": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "@type",
+            "identifier",
+            "name"
+          ]
+        },
+        "dateCreated": {
+          "type": "string"
+        },
+        "extras": {
+          "type": "object",
+          "properties": {
+            "botType": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "botType"
+          ]
+        },
+        "validatedSignatures": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "provider": {
+                "type": "string"
+              },
+              "algorithm": {
+                "type": "string"
+              },
+              "publicKey": {
+                "type": "string"
+              },
+              "custom": {
+                "type": "object",
+                "properties": {
+                  "IMG_123.jpg": {
+                    "type": "object",
+                    "properties": {
+                      "signature": {
+                        "type": "string"
+                      },
+                      "authenticatedMessage": {
+                        "type": "string"
+                      },
+                      "authenticatedMessageDescription": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "authenticatedMessage",
+                      "authenticatedMessageDescription",
+                      "signature"
+                    ]
+                  },
+                  "8045cb0d6783638e5828f3cca0ec3aab6ab5b9f8a971faf620a58f6cee1c7ca8.proof.csv": {
+                    "type": "object",
+                    "properties": {
+                      "signature": {
+                        "type": "string"
+                      },
+                      "authenticatedMessage": {
+                        "type": "string"
+                      },
+                      "authenticatedMessageDescription": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "authenticatedMessage",
+                      "authenticatedMessageDescription",
+                      "signature"
+                    ]
+                  }
+                },
+                "required": [
+                  "8045cb0d6783638e5828f3cca0ec3aab6ab5b9f8a971faf620a58f6cee1c7ca8.proof.csv",
+                  "IMG_123.jpg"
+                ]
+              }
+            },
+            "required": [
+              "algorithm",
+              "custom",
+              "provider",
+              "publicKey"
+            ]
+          }
+        },
+        "private": {
+          "type": "object",
+          "properties": {
+            "signal": {
+              "type": "object",
+              "properties": {
+                "target": {
+                  "type": "string"
+                },
+                "source": {
+                  "type": "string"
+                },
+                "sourceUUID": {
+                  "type": "string"
+                },
+                "timestamp": {
+                  "type": "string"
+                },
+                "timestampServer": {
+                  "type": "string"
+                },
+                "body": {
+                  "type": "string"
+                },
+                "sourceName": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "body",
+                "source",
+                "sourceName",
+                "sourceUUID",
+                "target",
+                "timestamp",
+                "timestampServer"
+              ]
+            },
+            "proofmode": {
+              "type": "object",
+              "properties": {
+                "20220608_162522.jpg": {
+                  "type": "object",
+                  "properties": {
+                    "pgpSignature": {
+                      "type": "string"
+                    },
+                    "pgpPublicKey": {
+                      "type": "string"
+                    },
+                    "sha256hash": {
+                      "type": "string"
+                    },
+                    "dateCreate": {
+                      "type": "string"
+                    },
+                    "proofmodeJSON": {
+                      "type": "object",
+                      "properties": {
+                        "File Hash SHA256": {
+                          "type": "string"
+                        },
+                        "Locale": {
+                          "type": "string"
+                        },
+                        "SafetyCheckCtsMatch": {
+                          "type": "string"
+                        },
+                        "Location.Provider": {
+                          "type": "string"
+                        },
+                        "IPv6": {
+                          "type": "string"
+                        },
+                        "IPv4": {
+                          "type": "string"
+                        },
+                        "Location.Accuracy": {
+                          "type": "string"
+                        },
+                        "Location.Latitude": {
+                          "type": "string"
+                        },
+                        "Language": {
+                          "type": "string"
+                        },
+                        "NetworkType": {
+                          "type": "string"
+                        },
+                        "Network": {
+                          "type": "string"
+                        },
+                        "Manufacturer": {
+                          "type": "string"
+                        },
+                        "DataType": {
+                          "type": "string"
+                        },
+                        "Hardware": {
+                          "type": "string"
+                        },
+                        "ScreenSize": {
+                          "type": "string"
+                        },
+                        "Wifi MAC": {
+                          "type": "string"
+                        },
+                        "Notes": {
+                          "type": "string"
+                        },
+                        "DeviceID": {
+                          "type": "string"
+                        },
+                        "Location.Longitude": {
+                          "type": "string"
+                        },
+                        "Location.Bearing": {
+                          "type": "string"
+                        },
+                        "SafetyCheckBasicIntegrity": {
+                          "type": "string"
+                        },
+                        "Location.Time": {
+                          "type": "string"
+                        },
+                        "File Modified": {
+                          "type": "string"
+                        },
+                        "CellInfo": {
+                          "type": "string"
+                        },
+                        "SafetyCheck": {
+                          "type": "string"
+                        },
+                        "Location.Altitude": {
+                          "type": "string"
+                        },
+                        "SafetyCheckTimestamp": {
+                          "type": "string"
+                        },
+                        "Proof Generated": {
+                          "type": "string"
+                        },
+                        "File Path": {
+                          "type": "string"
+                        },
+                        "Location.Speed": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "CellInfo",
+                        "DataType",
+                        "DeviceID",
+                        "File Hash SHA256",
+                        "File Modified",
+                        "File Path",
+                        "Hardware",
+                        "IPv4",
+                        "IPv6",
+                        "Language",
+                        "Locale",
+                        "Location.Accuracy",
+                        "Location.Altitude",
+                        "Location.Bearing",
+                        "Location.Latitude",
+                        "Location.Longitude",
+                        "Location.Provider",
+                        "Location.Speed",
+                        "Location.Time",
+                        "Manufacturer",
+                        "Network",
+                        "NetworkType",
+                        "Notes",
+                        "Proof Generated",
+                        "SafetyCheck",
+                        "SafetyCheckBasicIntegrity",
+                        "SafetyCheckCtsMatch",
+                        "SafetyCheckTimestamp",
+                        "ScreenSize",
+                        "Wifi MAC"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "dateCreate",
+                    "pgpPublicKey",
+                    "pgpSignature",
+                    "proofmodeJSON",
+                    "sha256hash"
+                  ]
+                },
+                "dateCreate": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "20220608_162522.jpg",
+                "dateCreate"
+              ]
+            }
+          },
+          "required": [
+            "proofmode",
+            "signal"
+          ]
+        }
+      },
+      "required": [
+        "author",
+        "dateCreated",
+        "description",
+        "extras",
+        "mime",
+        "name",
+        "private",
+        "validatedSignatures"
+      ]
+    },
+    "timestamp": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "contentMetadata",
+    "timestamp"
+  ]
+}

--- a/integrity-backend/input-proofmode-signal-examples/meta-content.schema.json
+++ b/integrity-backend/input-proofmode-signal-examples/meta-content.schema.json
@@ -63,27 +63,8 @@
               },
               "custom": {
                 "type": "object",
-                "properties": {
-                  "IMG_123.jpg": {
-                    "type": "object",
-                    "properties": {
-                      "signature": {
-                        "type": "string"
-                      },
-                      "authenticatedMessage": {
-                        "type": "string"
-                      },
-                      "authenticatedMessageDescription": {
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "authenticatedMessage",
-                      "authenticatedMessageDescription",
-                      "signature"
-                    ]
-                  },
-                  "8045cb0d6783638e5828f3cca0ec3aab6ab5b9f8a971faf620a58f6cee1c7ca8.proof.csv": {
+                "patternProperties": {
+                  "^.+$": {
                     "type": "object",
                     "properties": {
                       "signature": {
@@ -102,11 +83,7 @@
                       "signature"
                     ]
                   }
-                },
-                "required": [
-                  "8045cb0d6783638e5828f3cca0ec3aab6ab5b9f8a971faf620a58f6cee1c7ca8.proof.csv",
-                  "IMG_123.jpg"
-                ]
+                }
               }
             },
             "required": [
@@ -157,8 +134,8 @@
             },
             "proofmode": {
               "type": "object",
-              "properties": {
-                "20220608_162522.jpg": {
+              "patternProperties": {
+                "^.+\\.jpg$": {
                   "type": "object",
                   "properties": {
                     "pgpSignature": {
@@ -314,7 +291,6 @@
                 }
               },
               "required": [
-                "20220608_162522.jpg",
                 "dateCreate"
               ]
             }

--- a/integrity-backend/input-proofmode-signal-examples/meta-recorder.schema.json
+++ b/integrity-backend/input-proofmode-signal-examples/meta-recorder.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "recorderMetadata": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "service": {
+            "type": "string"
+          },
+          "info": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                },
+                "values": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "image": {
+                      "type": "string"
+                    },
+                    "repository": {
+                      "type": "string"
+                    },
+                    "branch": {
+                      "type": "string"
+                    },
+                    "commit": {
+                      "type": "string"
+                    },
+                    "clean": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              },
+              "required": [
+                "type",
+                "values"
+              ]
+            }
+          }
+        },
+        "required": [
+          "info",
+          "service"
+        ]
+      }
+    },
+    "timestamp": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "recorderMetadata",
+    "timestamp"
+  ]
+}

--- a/integrity-backend/input-starling-capture-examples/meta-content.schema.json
+++ b/integrity-backend/input-starling-capture-examples/meta-content.schema.json
@@ -1,0 +1,230 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "contentMetadata": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "mime": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "author": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string"
+            },
+            "identifier": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "identifier",
+            "name",
+            "type"
+          ]
+        },
+        "dateCreated": {
+          "type": "string"
+        },
+        "location": {
+          "type": "object",
+          "properties": {
+            "city": {
+              "type": "string"
+            },
+            "countryCode": {
+              "type": "string"
+            },
+            "countryName": {
+              "type": "string"
+            },
+            "provinceState": {
+              "type": "string"
+            },
+            "streetAddress": {
+              "type": "string"
+            },
+            "GPSLatitude": {
+              "type": "string"
+            },
+            "GPSLatitudeRef": {
+              "type": "string"
+            },
+            "GPSLongitude": {
+              "type": "string"
+            },
+            "GPSLongitudeRef": {
+              "type": "string"
+            },
+            "GPSTimeStamp": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "GPSLatitude",
+            "GPSLatitudeRef",
+            "GPSLongitude",
+            "GPSLongitudeRef",
+            "GPSTimeStamp",
+            "city",
+            "countryCode",
+            "countryName",
+            "provinceState",
+            "streetAddress"
+          ]
+        },
+        "extras": {
+          "type": "object",
+          "properties": {
+            "caption": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "caption"
+          ]
+        },
+        "validatedSignature": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "provider": {
+                "type": "string"
+              },
+              "algorithm": {
+                "type": "string"
+              },
+              "signature": {
+                "type": "string"
+              },
+              "publicKey": {
+                "type": "string"
+              },
+              "authenticatedMessage": {
+                "type": "string"
+              },
+              "authenticatedMessageDescription": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "algorithm",
+              "authenticatedMessage",
+              "authenticatedMessageDescription",
+              "provider",
+              "publicKey",
+              "signature"
+            ]
+          }
+        },
+        "private": {
+          "type": "object",
+          "properties": {
+            "meta": {
+              "type": "string"
+            },
+            "signature": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "proofHash": {
+                    "type": "string"
+                  },
+                  "provider": {
+                    "type": "string"
+                  },
+                  "signature": {
+                    "type": "string"
+                  },
+                  "publicKey": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "proofHash",
+                  "provider",
+                  "publicKey",
+                  "signature"
+                ]
+              }
+            },
+            "targetProvider": {
+              "type": "string"
+            },
+            "providerToken": {
+              "type": "object",
+              "properties": {
+                "organization_id": {
+                  "type": "string"
+                },
+                "collection_id": {
+                  "type": "string"
+                },
+                "author": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string"
+                    },
+                    "identifier": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "identifier",
+                    "name",
+                    "type"
+                  ]
+                }
+              },
+              "required": [
+                "author",
+                "collection_id",
+                "organization_id"
+              ]
+            }
+          },
+          "required": [
+            "meta",
+            "providerToken",
+            "signature",
+            "targetProvider"
+          ]
+        }
+      },
+      "required": [
+        "author",
+        "dateCreated",
+        "description",
+        "extras",
+        "location",
+        "mime",
+        "name",
+        "private",
+        "validatedSignature"
+      ]
+    },
+    "timestamp": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "contentMetadata",
+    "timestamp"
+  ]
+}

--- a/integrity-backend/input-starling-capture-examples/meta-recorder.schema.json
+++ b/integrity-backend/input-starling-capture-examples/meta-recorder.schema.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "recorderMetadata": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "service": {
+            "type": "string"
+          },
+          "info": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                },
+                "values": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "repository": {
+                      "type": "string"
+                    },
+                    "branch": {
+                      "type": "string"
+                    },
+                    "commit": {
+                      "type": "string"
+                    },
+                    "clean": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              },
+              "required": [
+                "type",
+                "values"
+              ]
+            }
+          }
+        },
+        "required": [
+          "info",
+          "service"
+        ]
+      }
+    },
+    "timestamp": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "recorderMetadata",
+    "timestamp"
+  ]
+}

--- a/integrity-backend/meta-content.schema.json
+++ b/integrity-backend/meta-content.schema.json
@@ -1,0 +1,948 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "contentMetadata": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "mime": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "author": {
+          "type": "object",
+          "properties": {
+            "@type": {
+              "type": "string"
+            },
+            "identifier": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "identifier",
+            "name"
+          ]
+        },
+        "dateCreated": {
+          "type": "string"
+        },
+        "extras": {
+          "type": "object",
+          "properties": {
+            "localsignSoftware": {
+              "type": "string"
+            },
+            "localsignPublicKey": {
+              "type": "string"
+            },
+            "localsignSignature": {
+              "type": "string"
+            },
+            "waczTitle": {
+              "type": "string"
+            },
+            "waczVersion": {
+              "type": "string"
+            },
+            "software": {
+              "type": "string"
+            },
+            "dateCrawled": {
+              "type": "string"
+            },
+            "pages": {
+              "type": "object",
+              "properties": {
+                "vngimrkldkpt682awhwrb": {
+                  "type": "string"
+                },
+                "5ZwqT9xGkYVdYku3EVQLrD": {
+                  "type": "string"
+                }
+              }
+            },
+            "authsignSoftware": {
+              "type": "string"
+            },
+            "authsignDomain": {
+              "type": "string"
+            },
+            "channels": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "dateRage": {
+              "type": "object",
+              "properties": {
+                "from": {
+                  "type": "string"
+                },
+                "to": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "from",
+                "to"
+              ]
+            },
+            "botType": {
+              "type": "string"
+            },
+            "caption": {
+              "type": "string"
+            }
+          }
+        },
+        "validatedSignatures": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "provider": {
+                "type": "string"
+              },
+              "algorithm": {
+                "type": "string"
+              },
+              "publicKey": {
+                "type": "string"
+              },
+              "signature": {
+                "type": "string"
+              },
+              "authenticatedMessage": {
+                "type": "string"
+              },
+              "authenticatedMessageDescription": {
+                "type": "string"
+              },
+              "custom": {
+                "type": "object",
+                "properties": {
+                  "hash": {
+                    "type": "string"
+                  },
+                  "created": {
+                    "type": "string"
+                  },
+                  "software": {
+                    "type": "string"
+                  },
+                  "signature": {
+                    "type": "string"
+                  },
+                  "domain": {
+                    "type": "string"
+                  },
+                  "domainCert": {
+                    "type": "string"
+                  },
+                  "timeSignature": {
+                    "type": "string"
+                  },
+                  "timestampCert": {
+                    "type": "string"
+                  },
+                  "version": {
+                    "type": "string"
+                  },
+                  "IMG_123.jpg": {
+                    "type": "object",
+                    "properties": {
+                      "signature": {
+                        "type": "string"
+                      },
+                      "authenticatedMessage": {
+                        "type": "string"
+                      },
+                      "authenticatedMessageDescription": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "authenticatedMessage",
+                      "authenticatedMessageDescription",
+                      "signature"
+                    ]
+                  },
+                  "8045cb0d6783638e5828f3cca0ec3aab6ab5b9f8a971faf620a58f6cee1c7ca8.proof.csv": {
+                    "type": "object",
+                    "properties": {
+                      "signature": {
+                        "type": "string"
+                      },
+                      "authenticatedMessage": {
+                        "type": "string"
+                      },
+                      "authenticatedMessageDescription": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "authenticatedMessage",
+                      "authenticatedMessageDescription",
+                      "signature"
+                    ]
+                  }
+                }
+              }
+            },
+            "required": [
+              "algorithm",
+              "provider"
+            ]
+          }
+        },
+        "private": {
+          "type": "object",
+          "properties": {
+            "uploaderName": {
+              "type": "string"
+            },
+            "uploadFilename": {
+              "type": "string"
+            },
+            "uploadDirectory": {
+              "type": "string"
+            },
+            "crawlConfigs": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "schedule": {
+                  "type": "string"
+                },
+                "config": {
+                  "type": "object",
+                  "properties": {
+                    "seeds": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "scopeType": {
+                      "type": "string"
+                    },
+                    "include": {
+                      "type": "null"
+                    },
+                    "exclude": {
+                      "type": "null"
+                    },
+                    "depth": {
+                      "type": "integer"
+                    },
+                    "limit": {
+                      "type": "integer"
+                    },
+                    "extraHops": {
+                      "type": "integer"
+                    },
+                    "behaviorTimeout": {
+                      "type": "null"
+                    },
+                    "workers": {
+                      "type": "null"
+                    },
+                    "headless": {
+                      "type": "null"
+                    },
+                    "generateWACZ": {
+                      "type": "null"
+                    },
+                    "combineWARC": {
+                      "type": "null"
+                    },
+                    "logging": {
+                      "type": "null"
+                    },
+                    "behaviors": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "behaviorTimeout",
+                    "behaviors",
+                    "combineWARC",
+                    "depth",
+                    "exclude",
+                    "extraHops",
+                    "generateWACZ",
+                    "headless",
+                    "include",
+                    "limit",
+                    "logging",
+                    "scopeType",
+                    "seeds",
+                    "workers"
+                  ]
+                },
+                "name": {
+                  "type": "string"
+                },
+                "created": {
+                  "type": "string"
+                },
+                "colls": {
+                  "type": "array"
+                },
+                "crawlTimeout": {
+                  "type": "integer"
+                },
+                "scale": {
+                  "type": "integer"
+                },
+                "aid": {
+                  "type": "string"
+                },
+                "userid": {
+                  "type": "string"
+                },
+                "crawlCount": {
+                  "type": "integer"
+                },
+                "lastCrawlId": {
+                  "type": "string"
+                },
+                "lastCrawlTime": {
+                  "type": "string"
+                },
+                "lastCrawlState": {
+                  "type": "string"
+                },
+                "newId": {
+                  "type": "null"
+                },
+                "oldId": {
+                  "type": "null"
+                },
+                "inactive": {
+                  "type": "boolean"
+                },
+                "currCrawlId": {
+                  "type": "null"
+                },
+                "userName": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "aid",
+                "colls",
+                "config",
+                "crawlCount",
+                "crawlTimeout",
+                "created",
+                "currCrawlId",
+                "id",
+                "inactive",
+                "lastCrawlId",
+                "lastCrawlState",
+                "lastCrawlTime",
+                "name",
+                "newId",
+                "oldId",
+                "scale",
+                "schedule",
+                "userName",
+                "userid"
+              ]
+            },
+            "crawlData": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "userid": {
+                  "type": "string"
+                },
+                "aid": {
+                  "type": "string"
+                },
+                "cid": {
+                  "type": "string"
+                },
+                "manual": {
+                  "type": "boolean"
+                },
+                "started": {
+                  "type": "string"
+                },
+                "finished": {
+                  "type": "string"
+                },
+                "state": {
+                  "type": "string"
+                },
+                "scale": {
+                  "type": "integer"
+                },
+                "completions": {
+                  "type": "integer"
+                },
+                "stats": {
+                  "type": "object",
+                  "properties": {
+                    "done": {
+                      "type": "string"
+                    },
+                    "found": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "done",
+                    "found"
+                  ]
+                },
+                "files": {
+                  "type": "array"
+                },
+                "colls": {
+                  "type": "array"
+                },
+                "userName": {
+                  "type": "string"
+                },
+                "configName": {
+                  "type": "string"
+                },
+                "resources": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "path": {
+                        "type": "string"
+                      },
+                      "hash": {
+                        "type": "string"
+                      },
+                      "size": {
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "hash",
+                      "name",
+                      "path",
+                      "size"
+                    ]
+                  }
+                },
+                "watchIPs": {
+                  "type": "array"
+                }
+              },
+              "required": [
+                "aid",
+                "cid",
+                "colls",
+                "completions",
+                "configName",
+                "files",
+                "finished",
+                "id",
+                "manual",
+                "resources",
+                "scale",
+                "started",
+                "state",
+                "stats",
+                "userName",
+                "userid",
+                "watchIPs"
+              ]
+            },
+            "additionalData": {
+              "type": "object",
+              "properties": {
+                "url_list": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "thread_ts": {
+                  "type": "string"
+                },
+                "ts": {
+                  "type": "string"
+                },
+                "client_msg_id": {
+                  "type": "string"
+                },
+                "attached_service": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "attached_ts": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  }
+                },
+                "attached_author": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "attached_text": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "country_codes": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "all_codes": {
+                  "type": "array"
+                }
+              },
+              "required": [
+                "all_codes",
+                "attached_author",
+                "attached_service",
+                "attached_text",
+                "attached_ts",
+                "client_msg_id",
+                "country_codes",
+                "thread_ts",
+                "ts",
+                "url_list"
+              ]
+            },
+            "signal": {
+              "type": "object",
+              "properties": {
+                "phoneNumber": {
+                  "type": "string"
+                },
+                "target": {
+                  "type": "string"
+                },
+                "source": {
+                  "type": "string"
+                },
+                "sourceUUID": {
+                  "type": "string"
+                },
+                "timestamp": {
+                  "type": "string"
+                },
+                "timestampServer": {
+                  "type": "string"
+                },
+                "body": {
+                  "type": "string"
+                },
+                "sourceName": {
+                  "type": "string"
+                }
+              }
+            },
+            "slack": {
+              "type": "object",
+              "properties": {
+                "botAccount": {
+                  "type": "string"
+                },
+                "workspace": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "botAccount",
+                "workspace"
+              ]
+            },
+            "telegram": {
+              "type": "object",
+              "properties": {
+                "botAccount": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "botAccount"
+              ]
+            },
+            "proofmode": {
+              "type": "object",
+              "properties": {
+                "20220608_162522.jpg": {
+                  "type": "object",
+                  "properties": {
+                    "pgpSignature": {
+                      "type": "string"
+                    },
+                    "pgpPublicKey": {
+                      "type": "string"
+                    },
+                    "sha256hash": {
+                      "type": "string"
+                    },
+                    "dateCreate": {
+                      "type": "string"
+                    },
+                    "proofmodeJSON": {
+                      "type": "object",
+                      "properties": {
+                        "File Hash SHA256": {
+                          "type": "string"
+                        },
+                        "Locale": {
+                          "type": "string"
+                        },
+                        "SafetyCheckCtsMatch": {
+                          "type": "string"
+                        },
+                        "Location.Provider": {
+                          "type": "string"
+                        },
+                        "IPv6": {
+                          "type": "string"
+                        },
+                        "IPv4": {
+                          "type": "string"
+                        },
+                        "Location.Accuracy": {
+                          "type": "string"
+                        },
+                        "Location.Latitude": {
+                          "type": "string"
+                        },
+                        "Language": {
+                          "type": "string"
+                        },
+                        "NetworkType": {
+                          "type": "string"
+                        },
+                        "Network": {
+                          "type": "string"
+                        },
+                        "Manufacturer": {
+                          "type": "string"
+                        },
+                        "DataType": {
+                          "type": "string"
+                        },
+                        "Hardware": {
+                          "type": "string"
+                        },
+                        "ScreenSize": {
+                          "type": "string"
+                        },
+                        "Wifi MAC": {
+                          "type": "string"
+                        },
+                        "Notes": {
+                          "type": "string"
+                        },
+                        "DeviceID": {
+                          "type": "string"
+                        },
+                        "Location.Longitude": {
+                          "type": "string"
+                        },
+                        "Location.Bearing": {
+                          "type": "string"
+                        },
+                        "SafetyCheckBasicIntegrity": {
+                          "type": "string"
+                        },
+                        "Location.Time": {
+                          "type": "string"
+                        },
+                        "File Modified": {
+                          "type": "string"
+                        },
+                        "CellInfo": {
+                          "type": "string"
+                        },
+                        "SafetyCheck": {
+                          "type": "string"
+                        },
+                        "Location.Altitude": {
+                          "type": "string"
+                        },
+                        "SafetyCheckTimestamp": {
+                          "type": "string"
+                        },
+                        "Proof Generated": {
+                          "type": "string"
+                        },
+                        "File Path": {
+                          "type": "string"
+                        },
+                        "Location.Speed": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "CellInfo",
+                        "DataType",
+                        "DeviceID",
+                        "File Hash SHA256",
+                        "File Modified",
+                        "File Path",
+                        "Hardware",
+                        "IPv4",
+                        "IPv6",
+                        "Language",
+                        "Locale",
+                        "Location.Accuracy",
+                        "Location.Altitude",
+                        "Location.Bearing",
+                        "Location.Latitude",
+                        "Location.Longitude",
+                        "Location.Provider",
+                        "Location.Speed",
+                        "Location.Time",
+                        "Manufacturer",
+                        "Network",
+                        "NetworkType",
+                        "Notes",
+                        "Proof Generated",
+                        "SafetyCheck",
+                        "SafetyCheckBasicIntegrity",
+                        "SafetyCheckCtsMatch",
+                        "SafetyCheckTimestamp",
+                        "ScreenSize",
+                        "Wifi MAC"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "dateCreate",
+                    "pgpPublicKey",
+                    "pgpSignature",
+                    "proofmodeJSON",
+                    "sha256hash"
+                  ]
+                },
+                "dateCreate": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "20220608_162522.jpg",
+                "dateCreate"
+              ]
+            },
+            "meta": {
+              "type": "string"
+            },
+            "signature": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "proofHash": {
+                    "type": "string"
+                  },
+                  "provider": {
+                    "type": "string"
+                  },
+                  "signature": {
+                    "type": "string"
+                  },
+                  "publicKey": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "proofHash",
+                  "provider",
+                  "publicKey",
+                  "signature"
+                ]
+              }
+            },
+            "targetProvider": {
+              "type": "string"
+            },
+            "providerToken": {
+              "type": "object",
+              "properties": {
+                "organization_id": {
+                  "type": "string"
+                },
+                "collection_id": {
+                  "type": "string"
+                },
+                "author": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string"
+                    },
+                    "identifier": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "identifier",
+                    "name",
+                    "type"
+                  ]
+                }
+              },
+              "required": [
+                "author",
+                "collection_id",
+                "organization_id"
+              ]
+            }
+          }
+        },
+        "timestamp": {
+          "type": "string"
+        },
+        "location": {
+          "type": "object",
+          "properties": {
+            "city": {
+              "type": "string"
+            },
+            "countryCode": {
+              "type": "string"
+            },
+            "countryName": {
+              "type": "string"
+            },
+            "provinceState": {
+              "type": "string"
+            },
+            "streetAddress": {
+              "type": "string"
+            },
+            "GPSLatitude": {
+              "type": "string"
+            },
+            "GPSLatitudeRef": {
+              "type": "string"
+            },
+            "GPSLongitude": {
+              "type": "string"
+            },
+            "GPSLongitudeRef": {
+              "type": "string"
+            },
+            "GPSTimeStamp": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "GPSLatitude",
+            "GPSLatitudeRef",
+            "GPSLongitude",
+            "GPSLongitudeRef",
+            "GPSTimeStamp",
+            "city",
+            "countryCode",
+            "countryName",
+            "provinceState",
+            "streetAddress"
+          ]
+        },
+        "validatedSignature": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "provider": {
+                "type": "string"
+              },
+              "algorithm": {
+                "type": "string"
+              },
+              "signature": {
+                "type": "string"
+              },
+              "publicKey": {
+                "type": "string"
+              },
+              "authenticatedMessage": {
+                "type": "string"
+              },
+              "authenticatedMessageDescription": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "algorithm",
+              "authenticatedMessage",
+              "authenticatedMessageDescription",
+              "provider",
+              "publicKey",
+              "signature"
+            ]
+          }
+        }
+      },
+      "required": [
+        "author",
+        "dateCreated",
+        "description",
+        "extras",
+        "mime",
+        "name",
+        "private"
+      ]
+    },
+    "sourceId": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "key",
+        "value"
+      ]
+    },
+    "timestamp": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "contentMetadata"
+  ]
+}

--- a/integrity-backend/meta-content.schema.json
+++ b/integrity-backend/meta-content.schema.json
@@ -64,11 +64,8 @@
             },
             "pages": {
               "type": "object",
-              "properties": {
-                "vngimrkldkpt682awhwrb": {
-                  "type": "string"
-                },
-                "5ZwqT9xGkYVdYku3EVQLrD": {
+              "patternProperties": {
+                "^.+$": {
                   "type": "string"
                 }
               }
@@ -160,27 +157,10 @@
                   },
                   "version": {
                     "type": "string"
-                  },
-                  "IMG_123.jpg": {
-                    "type": "object",
-                    "properties": {
-                      "signature": {
-                        "type": "string"
-                      },
-                      "authenticatedMessage": {
-                        "type": "string"
-                      },
-                      "authenticatedMessageDescription": {
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "authenticatedMessage",
-                      "authenticatedMessageDescription",
-                      "signature"
-                    ]
-                  },
-                  "8045cb0d6783638e5828f3cca0ec3aab6ab5b9f8a971faf620a58f6cee1c7ca8.proof.csv": {
+                  }
+                },
+                "patternProperties": {
+                  "^.+$": {
                     "type": "object",
                     "properties": {
                       "signature": {
@@ -199,7 +179,18 @@
                       "signature"
                     ]
                   }
-                }
+                },
+                "required": [
+                  "created",
+                  "domain",
+                  "domainCert",
+                  "hash",
+                  "signature",
+                  "software",
+                  "timeSignature",
+                  "timestampCert",
+                  "version"
+                ]
               }
             },
             "required": [
@@ -613,8 +604,8 @@
             },
             "proofmode": {
               "type": "object",
-              "properties": {
-                "20220608_162522.jpg": {
+              "patternProperties": {
+                "^.+\\.jpg$": {
                   "type": "object",
                   "properties": {
                     "pgpSignature": {
@@ -770,7 +761,6 @@
                 }
               },
               "required": [
-                "20220608_162522.jpg",
                 "dateCreate"
               ]
             },

--- a/integrity-backend/meta-content.schema.json
+++ b/integrity-backend/meta-content.schema.json
@@ -302,7 +302,10 @@
                   "type": "string"
                 },
                 "colls": {
-                  "type": "array"
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
                 },
                 "crawlTimeout": {
                   "type": "integer"
@@ -415,10 +418,16 @@
                   ]
                 },
                 "files": {
-                  "type": "array"
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
                 },
                 "colls": {
-                  "type": "array"
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
                 },
                 "userName": {
                   "type": "string"
@@ -453,7 +462,10 @@
                   }
                 },
                 "watchIPs": {
-                  "type": "array"
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
                 }
               },
               "required": [
@@ -525,7 +537,10 @@
                   }
                 },
                 "all_codes": {
-                  "type": "array"
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
                 }
               },
               "required": [

--- a/integrity-backend/meta-recorder.schema.json
+++ b/integrity-backend/meta-recorder.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "recorderMetadata": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "service": {
+            "type": "string"
+          },
+          "info": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                },
+                "values": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "image": {
+                      "type": "string"
+                    },
+                    "repository": {
+                      "type": "string"
+                    },
+                    "branch": {
+                      "type": "string"
+                    },
+                    "commit": {
+                      "type": "string"
+                    },
+                    "clean": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              },
+              "required": [
+                "type",
+                "values"
+              ]
+            }
+          }
+        },
+        "required": [
+          "info",
+          "service"
+        ]
+      }
+    },
+    "timestamp": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "recorderMetadata",
+    "timestamp"
+  ]
+}

--- a/integrity-backend/sig66_validated_signatures.schema.json
+++ b/integrity-backend/sig66_validated_signatures.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "provider": {
+      "type": "string"
+    },
+    "algorithm": {
+      "type": "string"
+    },
+    "publicKey": {
+      "type": "string"
+    },
+    "signature": {
+      "type": "string"
+    },
+    "authenticatedMessage": {
+      "type": "string"
+    },
+    "authenticatedMessageDescription": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "algorithm",
+    "authenticatedMessage",
+    "authenticatedMessageDescription",
+    "provider",
+    "publicKey",
+    "signature"
+  ]
+}


### PR DESCRIPTION
Related to https://github.com/starlinglab/integrity-schema/issues/12

#### Description

https://github.com/galargh/integrity-schema/blob/788fb35eca7876d99f22411d12088b4521f75bbc/integrity-backend/README.md is the main documentation entrypoint.

It shows the following schemas as markdown tables (key name, key type, description - in particular wether it's optional or not):
- validated signatures
- meta content (joint)
- meta content (per input type)
- meta recorder (joint)
- meta recorder (per input type) 

This PR also introduces JSON schema files per each of the aforementioned. The JSON schema files can be used for automatic validation of the JSONs.

The entire generation process can be easily replicated using shell scripts (it will come in handy when https://github.com/starlinglab/integrity-schema/issues/12#issuecomment-1332425355 is ready for example):
1. https://github.com/galargh/integrity-schema/blob/d4c5bd74e537df9145fff3ac356fc3aa9bf548f1/integrity-backend/generate-json-schemas.sh
1. https://github.com/galargh/integrity-schema/blob/d4c5bd74e537df9145fff3ac356fc3aa9bf548f1/integrity-backend/generate-joint-json-schemas.sh
1. https://github.com/galargh/integrity-schema/blob/788fb35eca7876d99f22411d12088b4521f75bbc/integrity-backend/generate-readme.sh

_NOTE_: Rerunning all the scripts will get rid of the manual updates applied to JSON schemas. See https://github.com/starlinglab/integrity-schema/commit/856d0aac3b90e92fd2a9e14449b02f5c7f19ad24 for example.
_NOTE2_: https://github.com/starlinglab/integrity-schema/commit/856d0aac3b90e92fd2a9e14449b02f5c7f19ad24 was created by introducing manual updates to input type specific JSON schemas and then running `generate-join-json-schemas.sh` and `generate-readme.sh`. It might be a useful workflow.

#### TODOs
- [ ] https://github.com/galargh/integrity-schema/blob/d4c5bd74e537df9145fff3ac356fc3aa9bf548f1/integrity-backend/TODO.md
- [ ] https://github.com/galargh/integrity-schema/blob/d4c5bd74e537df9145fff3ac356fc3aa9bf548f1/integrity-backend/input-browsertrix-examples/TODO.md