### PR TITLE
Remove geolocation field from proofmode

### DIFF
--- a/integrity-backend/input-proofmode-signal-examples/3e11cc57daf3bad8375935cad4878123acc8d769551ff90f1b1bb0dc597-meta-content.json
+++ b/integrity-backend/input-proofmode-signal-examples/3e11cc57daf3bad8375935cad4878123acc8d769551ff90f1b1bb0dc597-meta-content.json
@@ -32,17 +32,6 @@
       }
     ],
     "private": {
-      "geolocation": {
-        "latitude": "123.456",
-        "longitude": "-123.456",
-        "altitude": "123.456",
-        "timestamp": "2022-08-15T16:24:20.305Z",
-        "city": "Stockton",
-        "countryCode": "us",
-        "countryName": "United States",
-        "provinceState": "California",
-        "address": "123 Fake St, Stockton, California, 20002, United States"
-      },
       "signal": {
         "target": "+12899990286",
         "source": "+85264664092",


### PR DESCRIPTION
>  Remove geolocation block from Proofmode, since it doesn't make sense for multi-photo bundles

For https://github.com/starlinglab/integrity-backend/issues/120